### PR TITLE
Make the tests pass on Python 3, and add a six dependency

### DIFF
--- a/pyrsistent.py
+++ b/pyrsistent.py
@@ -3,6 +3,9 @@ from itertools import chain
 from functools import wraps
 from numbers import Integral
 
+import six
+
+
 def _bitcount(val):
     return bin(val).count("1")
 
@@ -669,7 +672,7 @@ def _turbo_mapping(initial, pre_size):
         # key collisions
         initial = dict(initial)
 
-    for k, v in initial.iteritems():
+    for k, v in six.iteritems(initial):
         h = hash(k)
         index = h % size
         bucket = buckets[index]
@@ -895,7 +898,7 @@ def immutable(members='', name='Immutable', verbose=False):
     AttributeError: Cannot set frozen members id_
     """
 
-    if isinstance(members, basestring):
+    if isinstance(members, six.string_types):
         members = members.replace(',', ' ').split()
 
     def frozen_member_test():
@@ -935,13 +938,13 @@ class {class_name}(namedtuple('ImmutableBase', [{quoted_members}], verbose={verb
                class_name=name)
 
     if verbose:
-        print template
+        print(template)
 
     from collections import namedtuple
     namespace = dict(namedtuple=namedtuple, __name__='pyrsistent_immutable')
     try:
-        exec template in namespace
-    except SyntaxError, e:
+        six.exec_(template, namespace)
+    except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + template)
 
     return namespace[name]

--- a/setup.py
+++ b/setup.py
@@ -76,4 +76,5 @@ setup(
     scripts=[],
     ext_modules=extensions,
     cmdclass={"build_ext": custom_build_ext},
+    install_requires=['six'],
 )

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -226,7 +226,7 @@ def test_bitmap_indexed_iteration():
 
 
 def test_iteration_with_many_elements():
-    values = range(0, 2000)
+    values = list(range(0, 2000))
     keys = [str(x) for x in values]
     init_dict = dict(zip(keys, values))
     

--- a/tests/set_test.py
+++ b/tests/set_test.py
@@ -1,3 +1,5 @@
+import six
+
 from pyrsistent import pset, s
 import pytest
 
@@ -86,7 +88,11 @@ def test_supports_set_comparisons():
 
 
 def test_str():
-    assert str(pset([1, 2, 3])) == "pset([1, 2, 3])"
+    rep = str(pset([1, 2, 3]))
+    if six.PY2:
+        assert rep == "pset([1, 2, 3])"
+    else:
+        assert rep == "p{1, 2, 3}"
 
 def test_is_disjoint():
     s1 = pset([1, 2, 3])


### PR DESCRIPTION
Couple notes:
- this probably needs some more work before we can really say python3 is supported, I literally did nothing other than run the unit tests
- should PMap's **repr** be changed to be consistent between python versions? I just changed the test.
- I didn't add a travis-ci entry. (pypy would also be a nice target)
