### PR TITLE
Include useful info about keys and indexes in raised exceptions

### DIFF
--- a/pvectorcmodule.c
+++ b/pvectorcmodule.c
@@ -161,7 +161,7 @@ static VNode* nodeFor(PVector *self, int i){
     return node;
   }
 
-  PyErr_SetString(PyExc_IndexError, "Index out of range");
+  PyErr_Format(PyExc_IndexError, "Index out of range: %i", i);
   return NULL;
 }
 
@@ -928,7 +928,7 @@ static PyObject* internalSet(PVector *self, Py_ssize_t position, PyObject *argOb
     // TODO Remove this case?
     return PVector_append(self, argObj);
   } else {
-    PyErr_SetString(PyExc_IndexError, "Index out of range");
+    PyErr_Format(PyExc_IndexError, "Index out of range: %i", position);
     return NULL;
   }
 }
@@ -1389,7 +1389,7 @@ static int PVectorEvolver_set_item(PVectorEvolver *self, PyObject* item, PyObjec
     } else if((0 <= position) && (position < (self->newVector->count + PyList_GET_SIZE(self->appendList) + 1))) {
       return PyList_Append(self->appendList, value); 
     } else {
-      PyErr_SetString(PyExc_IndexError, "Index out of range");
+      PyErr_Format(PyExc_IndexError, "Index out of range: %i", position);
     }
   } else {
     PyErr_Format(PyExc_TypeError, "Indices must be integers, not %.200s", item->ob_type->tp_name);

--- a/pyrsistent.py
+++ b/pyrsistent.py
@@ -182,7 +182,7 @@ class _PTrie(object):
             elif index == self._count + len(self._extra_tail):
                 self._extra_tail.append(val)
             else:
-                raise IndexError()
+                raise IndexError("Index out of range: %s" % (index,))
 
         def _do_set(self, level, node, i, val):
             if id(node) in self._dirty_nodes:
@@ -239,7 +239,7 @@ class _PTrie(object):
         if i == self._count:
             return self.append(val)
 
-        raise IndexError()
+        raise IndexError("Index out of range: %s" % (i,))
 
     def _do_set(self, level, node, i, val):
         ret = list(node)
@@ -263,7 +263,7 @@ class _PTrie(object):
 
             return node
 
-        raise IndexError()
+        raise IndexError("Index out of range: %s" % (i,))
 
     def _create_new_root(self):
         new_shift = self._shift
@@ -805,7 +805,7 @@ class PMap(object):
                 if k == key:
                     return v
 
-        raise KeyError
+        raise KeyError(key)
 
     def __getitem__(self, key):
         return PMap._getitem(self._buckets, key)

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -35,11 +35,22 @@ def test_initialization_with_one_element():
     assert len(empty_map) == 0
     assert 'a' not in empty_map
 
+
+def test_get_non_existing_raises_key_error():
+    m1 = m()
+    with pytest.raises(KeyError) as error:
+        m1['foo']
+
+    assert str(error.value) == "'foo'"
+
+
 def test_remove_non_existing_element_raises_key_error():
     m1 = m(a=1)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError) as error:
         m1.remove('b')
+
+    assert str(error.value) == "'b'"
 
 def test_various_iterations():
     assert set(['a', 'b']) == set(m(a=1, b=2))
@@ -328,8 +339,10 @@ def test_evolver_remove_element():
 def test_evolver_remove_element_not_present():
     e = m(a=1000, b=2000).evolver()
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError) as error:
         del e['c']
+
+    assert str(error.value) == "'c'"
 
 def test_copy_returns_reference_to_self():
     m1 = m(a=10)

--- a/tests/vector_test.py
+++ b/tests/vector_test.py
@@ -26,8 +26,9 @@ def test_empty_initialization(pvector):
     seq = pvector()
     assert len(seq) == 0
 
-    with pytest.raises(IndexError):
+    with pytest.raises(IndexError) as error:
         x = seq[0]
+    assert str(error.value) == 'Index out of range: 0'
 
 
 def test_initialization_with_one_element(pvector):
@@ -118,8 +119,10 @@ def test_insert_beyond_end(pvector):
     seq2 = seq.set(2, 50)
     assert seq2[2] == 50
 
-    with pytest.raises(IndexError):
+    with pytest.raises(IndexError) as error:
         seq2.set(19, 4)
+
+    assert str(error.value) == 'Index out of range: 19'
 
 
 def test_insert_with_index_from_the_end(pvector):
@@ -524,6 +527,13 @@ def test_evolver_simple_update_in_tree(pvector):
     assert e[10] == -10
     assert e.persistent()[10] == -10
 
+
+def test_evolver_set_out_of_range(pvector):
+    v = pvector([0])
+    e = v.evolver()
+    with pytest.raises(IndexError) as error:
+        e[10] = 1
+    assert str(error.value) == "Index out of range: 10"
 
 def test_evolver_multi_level_multi_update_in_tree(pvector):
     # This test is mostly to detect memory/ref count issues in the native implementation


### PR DESCRIPTION
Pretty straightforward: include indexes and keys in IndexError and KeyErrors that are raised. 