### PR TITLE
pset_field, pvector_field and pmap_field with tests and minimal docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -277,6 +277,19 @@ this behaviour.
     >>> ERecord.create({'d': {'x': '1'}})
     ERecord(d=DRecord(x=1))
 
+Collection fields
+*****************
+
+It is also possible to have fields with ``pyrsistent`` collections.
+
+.. code:: python
+
+   >>> class MultiRecord(PRecord):
+   ...     set_of_ints = pset_field(int)
+   ...     map_int_to_str = pmap_field(int, str)
+   ...     vector_of_strs = pvector_field(str)
+   ...
+	
 Serialization
 *************
 PRecords support serialization back to dicts. Default serialization will take keys and values

--- a/pyrsistent/__init__.py
+++ b/pyrsistent/__init__.py
@@ -14,7 +14,8 @@ from pyrsistent._pdeque import pdeque, dq, PDeque
 
 from pyrsistent._checked_types import CheckedPMap, CheckedPVector, CheckedPSet, InvariantException, CheckedKeyTypeError, CheckedValueTypeError, CheckedType, optional
 
-from pyrsistent._field_common import field, PTypeError
+from pyrsistent._field_common import (
+    field, PTypeError, pset_field, pmap_field, pvector_field)
 
 from pyrsistent._precord import PRecord
 

--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -1,5 +1,7 @@
 from collections import Iterable
-from pyrsistent import CheckedType
+from pyrsistent import (
+    CheckedType, CheckedPSet, CheckedPMap, CheckedPVector,
+    optional as optional_type)
 
 
 def _set_fields(dct, bases, name):
@@ -107,3 +109,99 @@ class PTypeError(TypeError):
         self.field = field
         self.expected_types = expected_types
         self.actual_type = actual_type
+
+
+def _sequence_field(checked_class, suffix, item_type, optional, initial):
+    """
+    Create checked field for either ``PSet`` or ``PVector``.
+
+    :param checked_class: ``CheckedPSet`` or ``CheckedPVector``.
+    :param suffix: Suffix for new type name.
+    :param item_type: The required type for the items in the set.
+    :param bool optional: If true, ``None`` can be used as a value for
+        this field.
+    :param initial: Initial value to pass to factory.
+
+    :return: A ``field`` containing a checked class.
+    """
+    class TheType(checked_class):
+        __type__ = item_type
+    TheType.__name__ = item_type.__name__.capitalize() + suffix
+
+    if optional:
+        def factory(argument):
+            if argument is None:
+                return None
+            else:
+                return TheType(argument)
+    else:
+        factory = TheType
+    return field(type=optional_type(TheType) if optional else TheType,
+                 factory=factory, mandatory=True,
+                 initial=factory(initial))
+
+
+def pset_field(item_type, optional=False, initial=()):
+    """
+    Create checked ``PSet`` field.
+
+    :param item_type: The required type for the items in the set.
+    :param bool optional: If true, ``None`` can be used as a value for
+        this field.
+    :param initial: Initial value to pass to factory if no value is given
+        for the field.
+
+    :return: A ``field`` containing a ``CheckedPSet`` of the given type.
+    """
+    return _sequence_field(CheckedPSet, "PSet", item_type, optional,
+                           initial)
+
+
+def pvector_field(item_type, optional=False, initial=()):
+    """
+    Create checked ``PVector`` field.
+
+    :param item_type: The required type for the items in the vector.
+    :param bool optional: If true, ``None`` can be used as a value for
+        this field.
+    :param initial: Initial value to pass to factory if no value is given
+        for the field.
+
+    :return: A ``field`` containing a ``CheckedPVector`` of the given type.
+    """
+    return _sequence_field(CheckedPVector, "PVector", item_type, optional,
+                           initial)
+
+
+_valid = lambda item: (True, "")
+
+
+def pmap_field(key_type, value_type, optional=False, invariant=_valid):
+    """
+    Create a checked ``PMap`` field.
+
+    :param key: The required type for the keys of the map.
+    :param value: The required type for the values of the map.
+    :param bool optional: If true, ``None`` can be used as a value for
+        this field.
+    :param invariant: Pass-through to ``field``.
+
+    :return: A ``field`` containing a ``CheckedPMap``.
+    """
+    class TheMap(CheckedPMap):
+        __key_type__ = key_type
+        __value_type__ = value_type
+    TheMap.__name__ = (key_type.__name__.capitalize() +
+                       value_type.__name__.capitalize() + "PMap")
+
+    if optional:
+        def factory(argument):
+            if argument is None:
+                return None
+            else:
+                return TheMap(argument)
+    else:
+        factory = TheMap
+    return field(mandatory=True, initial=TheMap(),
+                 type=optional_type(TheMap) if optional else TheMap,
+                 factory=factory, invariant=invariant)

--- a/tests/record_test.py
+++ b/tests/record_test.py
@@ -2,7 +2,10 @@ import pickle
 import datetime
 import pytest
 import six
-from pyrsistent import PRecord, field, InvariantException, ny, CheckedPSet, CheckedPVector, PTypeError
+from pyrsistent import (
+    PRecord, field, InvariantException, ny, pset, PSet, CheckedPVector,
+    PTypeError, pset_field, pvector_field, pmap_field, pmap, PMap,
+    pvector, PVector)
 
 
 class ARecord(PRecord):
@@ -300,3 +303,317 @@ def test_nested_create_serialize():
     restored = Node.create(serialized)
 
     assert restored == node
+
+
+def test_pset_field_initial_value():
+    """
+    ``pset_field`` results in initial value that is empty.
+    """
+    class Record(PRecord):
+        value = pset_field(int)
+    assert Record() == Record(value=[])
+
+def test_pset_field_custom_initial():
+    """
+    A custom initial value can be passed in.
+    """
+    class Record(PRecord):
+        value = pset_field(int, initial=(1, 2))
+    assert Record() == Record(value=[1, 2])
+
+def test_pset_field_factory():
+    """
+    ``pset_field`` has a factory that creates a ``PSet``.
+    """
+    class Record(PRecord):
+        value = pset_field(int)
+    record = Record(value=[1, 2])
+    assert isinstance(record.value, PSet)
+
+def test_pset_field_checked_set():
+    """
+    ``pset_field`` results in a set that enforces its type.
+    """
+    class Record(PRecord):
+        value = pset_field(int)
+    record = Record(value=[1, 2])
+    with pytest.raises(TypeError):
+        record.value.add("hello")
+
+def test_pset_field_type():
+    """
+    ``pset_field`` enforces its type.
+    """
+    class Record(PRecord):
+        value = pset_field(int)
+    record = Record()
+    with pytest.raises(TypeError):
+        record.set("value", None)
+
+def test_pset_field_mandatory():
+    """
+    ``pset_field`` is a mandatory field.
+    """
+    class Record(PRecord):
+        value = pset_field(int)
+    record = Record(value=[1])
+    with pytest.raises(InvariantException):
+        record.remove("value")
+
+def test_pset_field_default_non_optional():
+    """
+    By default ``pset_field`` is non-optional, i.e. does not allow
+    ``None``.
+    """
+    class Record(PRecord):
+        value = pset_field(int)
+    with pytest.raises(TypeError):
+        Record(value=None)
+
+def test_pset_field_explicit_non_optional():
+    """
+    If ``optional`` argument is ``False`` then ``pset_field`` is
+    non-optional, i.e. does not allow ``None``.
+    """
+    class Record(PRecord):
+        value = pset_field(int, optional=False)
+    with pytest.raises(TypeError):
+        Record(value=None)
+
+def test_pset_field_optional():
+    """
+    If ``optional`` argument is true, ``None`` is acceptable alternative
+    to a set.
+    """
+    class Record(PRecord):
+        value = pset_field(int, optional=True)
+    assert ((Record(value=[1, 2]).value, Record(value=None).value) ==
+            (pset([1, 2]), None))
+
+def test_pset_field_name():
+    """
+    The created set class name is based on the type of items in the set.
+    """
+    class Something(object):
+        pass
+
+    class Record(PRecord):
+        value = pset_field(Something)
+        value2 = pset_field(int)
+    assert ((Record().value.__class__.__name__,
+             Record().value2.__class__.__name__) ==
+            ("SomethingPSet", "IntPSet"))
+
+
+def test_pvector_field_initial_value():
+    """
+    ``pvector_field`` results in initial value that is empty.
+    """
+    class Record(PRecord):
+        value = pvector_field(int)
+    assert Record() == Record(value=[])
+
+def test_pvector_field_custom_initial():
+    """
+    A custom initial value can be passed in.
+    """
+    class Record(PRecord):
+        value = pvector_field(int, initial=(1, 2))
+    assert Record() == Record(value=[1, 2])
+
+def test_pvector_field_factory():
+    """
+    ``pvector_field`` has a factory that creates a ``PVector``.
+    """
+    class Record(PRecord):
+        value = pvector_field(int)
+    record = Record(value=[1, 2])
+    assert isinstance(record.value, PVector)
+
+def test_pvector_field_checked_vector():
+    """
+    ``pvector_field`` results in a vector that enforces its type.
+    """
+    class Record(PRecord):
+        value = pvector_field(int)
+    record = Record(value=[1, 2])
+    with pytest.raises(TypeError):
+        record.value.append("hello")
+
+def test_pvector_field_type():
+    """
+    ``pvector_field`` enforces its type.
+    """
+    class Record(PRecord):
+        value = pvector_field(int)
+    record = Record()
+    with pytest.raises(TypeError):
+        record.set("value", None)
+
+def test_pvector_field_mandatory():
+    """
+    ``pvector_field`` is a mandatory field.
+    """
+    class Record(PRecord):
+        value = pvector_field(int)
+    record = Record(value=[1])
+    with pytest.raises(InvariantException):
+        record.remove("value")
+
+def test_pvector_field_default_non_optional():
+    """
+    By default ``pvector_field`` is non-optional, i.e. does not allow
+    ``None``.
+    """
+    class Record(PRecord):
+        value = pvector_field(int)
+    with pytest.raises(TypeError):
+        Record(value=None)
+
+def test_pvector_field_explicit_non_optional():
+    """
+    If ``optional`` argument is ``False`` then ``pvector_field`` is
+    non-optional, i.e. does not allow ``None``.
+    """
+    class Record(PRecord):
+        value = pvector_field(int, optional=False)
+    with pytest.raises(TypeError):
+        Record(value=None)
+
+def test_pvector_field_optional():
+    """
+    If ``optional`` argument is true, ``None`` is acceptable alternative
+    to a sequence.
+    """
+    class Record(PRecord):
+        value = pvector_field(int, optional=True)
+    assert ((Record(value=[1, 2]).value, Record(value=None).value) ==
+            (pvector([1, 2]), None))
+
+def test_pvector_field_name():
+    """
+    The created set class name is based on the type of items in the set.
+    """
+    class Something(object):
+        pass
+
+    class Record(PRecord):
+        value = pvector_field(Something)
+        value2 = pvector_field(int)
+    assert ((Record().value.__class__.__name__,
+             Record().value2.__class__.__name__) ==
+            ("SomethingPVector", "IntPVector"))
+
+
+def test_pmap_field_initial_value():
+    """
+    ``pmap_field`` results in initial value that is empty.
+    """
+    class Record(PRecord):
+        value = pmap_field(int, int)
+    assert Record() == Record(value={})
+
+def test_pmap_field_factory():
+    """
+    ``pmap_field`` has a factory that creates a ``PMap``.
+    """
+    class Record(PRecord):
+        value = pmap_field(int, int)
+    record = Record(value={1:  1234})
+    assert isinstance(record.value, PMap)
+
+def test_pmap_field_checked_map_key():
+    """
+    ``pmap_field`` results in a map that enforces its key type.
+    """
+    class Record(PRecord):
+        value = pmap_field(int, type(None))
+    record = Record(value={1: None})
+    with pytest.raises(TypeError):
+        record.value.set("hello", None)
+
+def test_pmap_field_checked_map_value():
+    """
+    ``pmap_field`` results in a map that enforces its value type.
+    """
+    class Record(PRecord):
+        value = pmap_field(int, type(None))
+    record = Record(value={1: None})
+    with pytest.raises(TypeError):
+        record.value.set(2, 4)
+
+def test_pmap_field_mandatory():
+    """
+    ``pmap_field`` is a mandatory field.
+    """
+    class Record(PRecord):
+        value = pmap_field(int, int)
+    record = Record()
+    with pytest.raises(InvariantException):
+        record.remove("value")
+
+def test_pmap_field_default_non_optional():
+    """
+    By default ``pmap_field`` is non-optional, i.e. does not allow
+    ``None``.
+    """
+    class Record(PRecord):
+        value = pmap_field(int, int)
+    # Ought to be TypeError, but pyrsistent doesn't quite allow that:
+    with pytest.raises(AttributeError):
+        Record(value=None)
+
+def test_pmap_field_explicit_non_optional():
+    """
+    If ``optional`` argument is ``False`` then ``pmap_field`` is
+    non-optional, i.e. does not allow ``None``.
+    """
+    class Record(PRecord):
+        value = pmap_field(int, int, optional=False)
+    # Ought to be TypeError, but pyrsistent doesn't quite allow that:
+    with pytest.raises(AttributeError):
+        Record(value=None)
+
+def test_pmap_field_optional():
+    """
+    If ``optional`` argument is true, ``None`` is acceptable alternative
+    to a set.
+    """
+    class Record(PRecord):
+        value = pmap_field(int, int, optional=True)
+    assert ((Record(value={1: 2}).value, Record(value=None).value) ==
+            pmap({1: 2}), None)
+
+def test_pmap_field_name():
+    """
+    The created map class name is based on the types of items in the map.
+    """
+    class Something(object):
+        pass
+
+    class Another(object):
+        pass
+
+    class Record(PRecord):
+        value = pmap_field(Something, Another)
+        value2 = pmap_field(int, float)
+    assert ((Record().value.__class__.__name__,
+             Record().value2.__class__.__name__) ==
+            ("SomethingAnotherPMap", "IntFloatPMap"))
+
+def test_pmap_field_invariant():
+    """
+    The ``invariant`` parameter is passed through to ``field``.
+    """
+    class Record(PRecord):
+        value = pmap_field(
+            int, int,
+            invariant=(
+                lambda pmap: (len(pmap) == 1, "Exactly one item required.")
+            )
+        )
+    with pytest.raises(InvariantException):
+        Record(value={})
+    with pytest.raises(InvariantException):
+        Record(value={1: 2, 3: 4})
+    assert Record(value={1: 2}).value == {1: 2}


### PR DESCRIPTION
Fixes #26.

Notice that there's not complete feature coverage, unfortunately; two classes have initial override but no invariant, and one has invariant but no initial override. And there is still some duplication in terms of implementation. Even in this state, however, this saves us lots of typing at work.