### PR TITLE
add `delete` to PythonPVector

### DIFF
--- a/pyrsistent/_pvector.py
+++ b/pyrsistent/_pvector.py
@@ -380,6 +380,24 @@ class PythonPVector(object):
     def count(self, value):
         return self.tolist().count(value)
 
+    def delete(self, index, stop=None):
+        """
+        Delete a portion of the vector by index or range.
+        """
+        if index < 0:
+            index = len(self) + index
+        if stop is None:
+            # convention is to only raise IndexError for index OOB, not slices
+            if not (0 <= index < len(self)):
+                raise IndexError(index)
+            stop = index + 1
+        elif stop < 0:
+            stop = len(self) + stop
+        elif stop < index:
+            return self
+        return self[:index] + self[stop:]
+
+
 @six.add_metaclass(ABCMeta)
 class PVector(object):
     """

--- a/tests/vector_test.py
+++ b/tests/vector_test.py
@@ -1,6 +1,9 @@
 import pickle
 import pytest
 
+from pyrsistent._pvector import python_pvector
+
+
 @pytest.fixture(scope='session', params=['pyrsistent._pvector', 'pvectorc'])
 def pvector(request):
     m = pytest.importorskip(request.param)
@@ -229,6 +232,33 @@ def test_slicing_reverse(pvector):
     assert seq3[0] == 7
     assert seq3[3] == 4
     assert len(seq3) == 4
+
+
+def test_delete_index():
+    seq = python_pvector([1, 2, 3])
+    assert seq.delete(0) == python_pvector([2, 3])
+    assert seq.delete(1) == python_pvector([1, 3])
+    assert seq.delete(2) == python_pvector([1, 2])
+    assert seq.delete(-1) == python_pvector([1, 2])
+    assert seq.delete(-2) == python_pvector([1, 3])
+    assert seq.delete(-3) == python_pvector([2, 3])
+
+
+def test_delete_index_out_of_bounds():
+    with pytest.raises(IndexError):
+        python_pvector([]).delete(0)
+    with pytest.raises(IndexError):
+        python_pvector([]).delete(-1)
+
+
+def test_delete_slice():
+    seq = python_pvector(range(5))
+    assert seq.delete(1, 4) == python_pvector([0, 4])
+    assert seq.delete(4, 1) == seq
+    assert seq.delete(0, 1) == python_pvector([1, 2, 3, 4])
+    assert seq.delete(6, 8) == seq
+    assert seq.delete(-1, 1) == seq
+    assert seq.delete(1, -1) == python_pvector([0, 4])
 
 
 def test_addition(pvector):


### PR DESCRIPTION
For #42

Supports deletion by index, as well as start:stop indices. I attempted to emulate the semantics of `list.__delitem__` faithfully, especially with respect to when to raise IndexError and when to just treat an out-of-bound index as equal to the bounds of the list.

shortcomings:
- no implementation in C vector yet
- no "step" argument to emulate `del l[start:stop:step]` (I've never seen a need for that with `del`, but...)
- no `evolver.__delitem__`... I figured I'd just submit this since without it since it'll take me a while to figure out the internals of the datastructure :)

