### PR TITLE
Fix bug where PMap evolver loses writes

### DIFF
--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -340,20 +340,15 @@ def test_evolver_set_with_reallocation_edge_case():
     # Demonstrates a bug in evolver that also affects updates. Under certain
     # circumstances, the result of `x.update(y)` will **not** have all the
     # keys from `y`.
-    x = {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6,
-         'g': 7, 'h': 8, 'i': 9, 'j': 10, 'k': 11}
-    y = pmap().update(x)
-    # At this point, y has size 11 & buckets 8, so next new element will
-    # trigger reallocate.
-    e = y.evolver()
-    e.set('NEW', 'STUFF')
-    e.set('k', x['k'])  # If we use a different value, the problem goes away.
-    z = e.persistent()
+    foo = object()
+    x = pmap({'a': foo}, pre_size=1)
+    e = x.evolver()
+    e['b'] = 3000
+    # Bug is triggered when we do a reallocation and the new value is
+    # identical to the old one.
+    e['a'] = foo
 
-    assert 'NEW' in z  # Clearer error message.
-    assert z == pmap(
-        {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6,
-         'g': 7, 'h': 8, 'i': 9, 'j': 10, 'k': 11, 'NEW': 'STUFF'})
+    assert 'b' in e.persistent()
 
 
 def test_evolver_remove_element():


### PR DESCRIPTION
We've started using [Hypothesis](http://hypothesis.readthedocs.org/en/latest/) to test our code. It's great at finding bugs, and I highly recommend using it for pyrsistent.

One of the bugs it found was that sometimes we would update a pmap with a dictionary (e.g. `z = x.update(y)`), but not all of the keys in `y` would appear in `z`. That is, it would lose writes to the pmap.

I've poked around and figured out what's happening: 

Given an evolver `e` on a map, we
* set an item to a map so that it hits the reallocate threshold
* reallocation doesn't happen yet because it only happens at the start of a set
* set another item, but this time with an existing key and **identical** value
* reallocation is triggered, leaving `e._buckets_evolver` clean, and thus `e` clean
* for an identical value, `set` makes no further changes to `e._buckets_evolver`, leaving it clean
* `e.persistent()` sees that the evolver is clean and returns the original map

We noticed the problem with `update`, which made the whole thing rather tricky to debug, since it was triggered depending on dict ordering. It can be reproduced reliably with `set` though. 

This PR adds a test that demonstrates the bug, and my own attempt at solving the problem. 

Let me know what you think.

Thanks,
jml

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tobgu/pyrsistent/54)
<!-- Reviewable:end -->
