### PR TITLE
Support pickling of PClasses and PRecords using pmap_field, pvector_field, and pset_field

### DIFF
--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -2,13 +2,21 @@ from collections import Hashable
 import math
 import pickle
 import pytest
-from pyrsistent import field, InvariantException, PClass, optional, CheckedPVector
+from pyrsistent import (
+    field, InvariantException, PClass, optional, CheckedPVector,
+    pmap_field, pset_field, pvector_field)
 
 
 class Point(PClass):
     x = field(type=int, mandatory=True, invariant=lambda x: (x >= 0, 'X negative'))
     y = field(type=int, serializer=lambda formatter, y: formatter(y))
     z = field(type=int, initial=0)
+
+
+class TypedContainerObj(PClass):
+    map = pmap_field(str, str)
+    set = pset_field(str)
+    vec = pvector_field(str)
 
 
 def test_evolve_pclass_instance():
@@ -163,6 +171,12 @@ def test_supports_pickling():
 
     assert p1 == p2
     assert isinstance(p2, Point)
+
+
+def test_supports_pickling_with_typed_fields():
+    obj = TypedContainerObj(map={'foo': 'bar'}, set=['hello', 'there'], vec=['a', 'b'])
+    obj2 = pickle.loads(pickle.dumps(obj))
+    assert obj == obj2
 
 
 def test_can_remove_optional_member():

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -173,7 +173,7 @@ def test_supports_pickling():
     assert isinstance(p2, Point)
 
 
-def test_supports_pickling_with_typed_fields():
+def test_supports_pickling_with_typed_container_fields():
     obj = TypedContainerObj(map={'foo': 'bar'}, set=['hello', 'there'], vec=['a', 'b'])
     obj2 = pickle.loads(pickle.dumps(obj))
     assert obj == obj2

--- a/tests/record_test.py
+++ b/tests/record_test.py
@@ -13,6 +13,12 @@ class ARecord(PRecord):
     y = field()
 
 
+class RecordContainingContainers(PRecord):
+    map = pmap_field(str, str)
+    vec = pvector_field(str)
+    set = pset_field(str)
+
+
 def test_create():
     r = ARecord(x=1, y='foo')
     assert r.x == 1
@@ -223,6 +229,11 @@ def test_pickling():
     assert x == y
     assert isinstance(y, ARecord)
 
+def test_supports_pickling_with_typed_container_fields():
+    obj = RecordContainingContainers(
+        map={'foo': 'bar'}, set=['hello', 'there'], vec=['a', 'b'])
+    obj2 = pickle.loads(pickle.dumps(obj))
+    assert obj == obj2
 
 def test_all_invariant_errors_reported():
     class BRecord(PRecord):


### PR DESCRIPTION
Fixes #56 -- though see that ticket for some caveats about this solution.


These field types generate classes on the fly, and so they need special pickling support.

Interesting notes:

1. now all equivalent auto-generated types are reused between different fields. so if there were previously multiple fields declared with `pvector_field(int)`, they will all be instances of the same type now.
2. I refactored the way "suffix" was being used in the pvec / pset generation, to avoid needing to pickle it.
