### PR TITLE
Tests and implementation for checked collection fields with multiple types

### DIFF
--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -135,6 +135,10 @@ def _restore_seq_field_pickle(checked_class, item_type, data):
     type_ = _seq_field_types[checked_class, item_type]
     return _restore_pickle(type_, data)
 
+def _types_to_names(types):
+    """Convert a tuple of types to a human-readable string."""
+    return "".join(typ.__name__.capitalize() for typ in types)
+
 def _make_seq_field_type(checked_class, item_type):
     """Create a subclass of the given checked class with the given item type."""
     type_ = _seq_field_types.get((checked_class, item_type))
@@ -149,7 +153,7 @@ def _make_seq_field_type(checked_class, item_type):
                     (checked_class, item_type, list(self)))
 
     suffix = SEQ_FIELD_TYPE_SUFFIXES[checked_class]
-    TheType.__name__ = item_type.__name__.capitalize() + suffix
+    TheType.__name__ = _types_to_names(TheType._checked_types) + suffix
     _seq_field_types[checked_class, item_type] = TheType
     return TheType
 
@@ -238,8 +242,9 @@ def _make_pmap_field_type(key_type, value_type):
             return (_restore_pmap_field_pickle,
                     (self.__key_type__, self.__value_type__, dict(self)))
 
-    TheMap.__name__ = (key_type.__name__.capitalize() +
-                       value_type.__name__.capitalize() + "PMap")
+    TheMap.__name__ = "{}To{}PMap".format(
+        _types_to_names(TheMap._checked_key_types),
+        _types_to_names(TheMap._checked_value_types))
     _pmap_field_types[key_type, value_type] = TheMap
     return TheMap
 

--- a/tests/record_test.py
+++ b/tests/record_test.py
@@ -358,6 +358,16 @@ def test_pset_field_checked_set():
     with pytest.raises(TypeError):
         record.value.add("hello")
 
+def test_pset_field_checked_vector_multiple_types():
+    """
+    ``pset_field`` results in a vector that enforces its types.
+    """
+    class Record(PRecord):
+        value = pset_field((int, str))
+    record = Record(value=[1, 2, "hello"])
+    with pytest.raises(TypeError):
+        record.value.add(object())
+
 def test_pset_field_type():
     """
     ``pset_field`` enforces its type.
@@ -422,6 +432,19 @@ def test_pset_field_name():
              Record().value2.__class__.__name__) ==
             ("SomethingPSet", "IntPSet"))
 
+def test_pset_multiple_types_field_name():
+    """
+    The created set class name is based on the multiple given types of
+    items in the set.
+    """
+    class Something(object):
+        pass
+
+    class Record(PRecord):
+        value = pset_field((Something, int))
+
+    assert (Record().value.__class__.__name__ ==
+            "SomethingIntPSet")
 
 def test_pvector_field_initial_value():
     """
@@ -457,6 +480,16 @@ def test_pvector_field_checked_vector():
     record = Record(value=[1, 2])
     with pytest.raises(TypeError):
         record.value.append("hello")
+
+def test_pvector_field_checked_vector_multiple_types():
+    """
+    ``pvector_field`` results in a vector that enforces its types.
+    """
+    class Record(PRecord):
+        value = pvector_field((int, str))
+    record = Record(value=[1, 2, "hello"])
+    with pytest.raises(TypeError):
+        record.value.append(object())
 
 def test_pvector_field_type():
     """
@@ -522,6 +555,20 @@ def test_pvector_field_name():
              Record().value2.__class__.__name__) ==
             ("SomethingPVector", "IntPVector"))
 
+def test_pvector_multiple_types_field_name():
+    """
+    The created vector class name is based on the multiple given types of
+    items in the vector.
+    """
+    class Something(object):
+        pass
+
+    class Record(PRecord):
+        value = pvector_field((Something, int))
+
+    assert (Record().value.__class__.__name__ ==
+            "SomethingIntPVector")
+
 def test_pvector_field_create_from_nested_serialized_data():
     class Foo(PRecord):
         foo = field(type=str)
@@ -566,6 +613,26 @@ def test_pmap_field_checked_map_value():
     class Record(PRecord):
         value = pmap_field(int, type(None))
     record = Record(value={1: None})
+    with pytest.raises(TypeError):
+        record.value.set(2, 4)
+
+def test_pmap_field_checked_map_key_multiple_types():
+    """
+    ``pmap_field`` results in a map that enforces its key types.
+    """
+    class Record(PRecord):
+        value = pmap_field((int, str), type(None))
+    record = Record(value={1: None, "hello": None})
+    with pytest.raises(TypeError):
+        record.value.set(object(), None)
+
+def test_pmap_field_checked_map_value_multiple_types():
+    """
+    ``pmap_field`` results in a map that enforces its value types.
+    """
+    class Record(PRecord):
+        value = pmap_field(int, (str, type(None)))
+    record = Record(value={1: None, 3: "hello"})
     with pytest.raises(TypeError):
         record.value.set(2, 4)
 
@@ -626,7 +693,25 @@ def test_pmap_field_name():
         value2 = pmap_field(int, float)
     assert ((Record().value.__class__.__name__,
              Record().value2.__class__.__name__) ==
-            ("SomethingAnotherPMap", "IntFloatPMap"))
+            ("SomethingToAnotherPMap", "IntToFloatPMap"))
+
+def test_pmap_field_name_multiple_types():
+    """
+    The created map class name is based on the types of items in the map,
+    including when there are multiple supported types.
+    """
+    class Something(object):
+        pass
+
+    class Another(object):
+        pass
+
+    class Record(PRecord):
+        value = pmap_field((Something, Another), int)
+        value2 = pmap_field(str, (int, float))
+    assert ((Record().value.__class__.__name__,
+             Record().value2.__class__.__name__) ==
+            ("SomethingAnotherToIntPMap", "StrToIntFloatPMap"))
 
 def test_pmap_field_invariant():
     """


### PR DESCRIPTION
`CheckedPVector` etc. support multiple types, but until this patch the `pvector_field` etc wrappers didn't.

Minor incompatibility: class name changed for `pmap_field` `CheckedPMap` subclasses. Looks like won't impact pickling but worth checking.