### PR TITLE
Add `remove` method to vectors

### DIFF
--- a/pyrsistent/_pvector.py
+++ b/pyrsistent/_pvector.py
@@ -406,6 +406,9 @@ class PythonPVector(object):
         del l[_index_or_slice(index, stop)]
         return _EMPTY_PVECTOR.extend(l)
 
+    def remove(self, value):
+        return self.delete(self.index(value))
+
 
 @six.add_metaclass(ABCMeta)
 class PVector(object):
@@ -656,6 +659,19 @@ class PVector(object):
         >>> v1.delete(1, 3)
         pvector([1, 4, 5])
         """
+
+    @abstractmethod
+    def remove(self, value):
+        """
+        Remove the occurrence of a value from the vector.
+
+        >>> v1 = v(1, 2, 3, 2, 1)
+        >>> v2 = v1.remove(1)
+        pvector([2, 3, 2, 1])
+        >>> v2.remove(1)
+        pvector([2, 3, 2])
+        """
+
 
 _EMPTY_PVECTOR = PythonPVector(0, SHIFT, [], [])
 PVector.register(PythonPVector)

--- a/pyrsistent/_pvector.py
+++ b/pyrsistent/_pvector.py
@@ -663,7 +663,7 @@ class PVector(object):
     @abstractmethod
     def remove(self, value):
         """
-        Remove the occurrence of a value from the vector.
+        Remove the first occurrence of a value from the vector.
 
         >>> v1 = v(1, 2, 3, 2, 1)
         >>> v2 = v1.remove(1)

--- a/tests/vector_test.py
+++ b/tests/vector_test.py
@@ -266,6 +266,23 @@ def test_delete_slice(pvector):
     assert seq.delete(1, -1) == pvector([0, 4])
 
 
+def test_remove(pvector):
+    seq = pvector(range(5))
+    assert seq.remove(3) == pvector([0, 1, 2, 4])
+
+
+def test_remove_first_only(pvector):
+    seq = pvector([1, 2, 3, 2, 1])
+    assert seq.remove(2) == pvector([1, 3, 2, 1])
+
+
+def test_remove_index_out_of_bounds(pvector):
+    seq = pvector(range(5))
+    with pytest.raises(ValueError) as err:
+        seq.remove(5)
+    assert str(err.value) == '5 is not in list'
+
+
 def test_addition(pvector):
     v = pvector([1, 2]) + pvector([3, 4])
 


### PR DESCRIPTION
No C implementation yet.

I doubt the C implementation would be significantly faster than this Python implementation -- maybe we could add a subclass of the (dynamic) pvector base class for these kinds of trivial methods that just call other methods on vector?
