### PR TITLE
Skip field factories when loading pickled objects

### DIFF
--- a/pyrsistent/_checked_types.py
+++ b/pyrsistent/_checked_types.py
@@ -12,7 +12,7 @@ class CheckedType(object):
     __slots__ = ()
 
     @classmethod
-    def create(cls, source_data):
+    def create(cls, source_data, _bypass_factories=False):
         raise NotImplementedError()
 
     def serialize(self, format=None):
@@ -20,7 +20,7 @@ class CheckedType(object):
 
 
 def _restore_pickle(cls, data):
-    return cls.create(data)
+    return cls.create(data, _bypass_factories=True)
 
 
 class InvariantException(Exception):
@@ -207,7 +207,7 @@ def optional(*typs):
     return tuple(typs) + (type(None),)
 
 
-def _checked_type_create(cls, source_data):
+def _checked_type_create(cls, source_data, _bypass_factories=False):
         if isinstance(source_data, cls):
             return source_data
 
@@ -447,7 +447,7 @@ class CheckedPMap(PMap, CheckedType):
         return dict(serializer(format, k, v) for k, v in self.items())
 
     @classmethod
-    def create(cls, source_data):
+    def create(cls, source_data, _bypass_factories=False):
         if isinstance(source_data, cls):
             return source_data
 

--- a/pyrsistent/_precord.py
+++ b/pyrsistent/_precord.py
@@ -38,13 +38,15 @@ class PRecord(PMap, CheckedType):
         if '_precord_size' in kwargs and '_precord_buckets' in kwargs:
             return super(PRecord, cls).__new__(cls, kwargs['_precord_size'], kwargs['_precord_buckets'])
 
+        bypass_factories = kwargs.pop('_bypass_factories', False)
+
         initial_values = kwargs
         if cls._precord_initial_values:
             initial_values = dict((k, v() if callable(v) else v)
                                   for k, v in cls._precord_initial_values.items())
             initial_values.update(kwargs)
 
-        e = _PRecordEvolver(cls, pmap())
+        e = _PRecordEvolver(cls, pmap(), _bypass_factories=bypass_factories)
         for k, v in initial_values.items():
             e[k] = v
 
@@ -75,7 +77,7 @@ class PRecord(PMap, CheckedType):
                                  ', '.join('{0}={1}'.format(k, repr(v)) for k, v in self.items()))
 
     @classmethod
-    def create(cls, kwargs):
+    def create(cls, kwargs, _bypass_factories=False):
         """
         Factory method. Will create a new PRecord of the current type and assign the values
         specified in kwargs.
@@ -83,7 +85,7 @@ class PRecord(PMap, CheckedType):
         if isinstance(kwargs, cls):
             return kwargs
 
-        return cls(**kwargs)
+        return cls(_bypass_factories=_bypass_factories, **kwargs)
 
     def __reduce__(self):
         # Pickling support
@@ -98,13 +100,14 @@ class PRecord(PMap, CheckedType):
 
 
 class _PRecordEvolver(PMap._Evolver):
-    __slots__ = ('_destination_cls', '_invariant_error_codes', '_missing_fields')
+    __slots__ = ('_destination_cls', '_invariant_error_codes', '_missing_fields', '_bypass_factories')
 
-    def __init__(self, cls, *args):
-        super(_PRecordEvolver, self).__init__(*args)
+    def __init__(self, cls, original_pmap, _bypass_factories=False):
+        super(_PRecordEvolver, self).__init__(original_pmap)
         self._destination_cls = cls
         self._invariant_error_codes = []
         self._missing_fields = []
+        self._bypass_factories = _bypass_factories
 
     def __setitem__(self, key, original_value):
         self.set(key, original_value)
@@ -112,12 +115,15 @@ class _PRecordEvolver(PMap._Evolver):
     def set(self, key, original_value):
         field = self._destination_cls._precord_fields.get(key)
         if field:
-            try:
-                value = field.factory(original_value)
-            except InvariantException as e:
-                self._invariant_error_codes += e.invariant_errors
-                self._missing_fields += e.missing_fields
-                return self
+            if not self._bypass_factories:
+                try:
+                    value = field.factory(original_value)
+                except InvariantException as e:
+                    self._invariant_error_codes += e.invariant_errors
+                    self._missing_fields += e.missing_fields
+                    return self
+            else:
+                value = original_value
 
             check_type(self._destination_cls, field, key, value)
 

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -3,6 +3,7 @@ import math
 import pickle
 import pytest
 import sys
+import uuid
 from pyrsistent import (
     field, InvariantException, PClass, optional, CheckedPVector,
     pmap_field, pset_field, pvector_field)
@@ -18,6 +19,10 @@ class TypedContainerObj(PClass):
     map = pmap_field(str, str)
     set = pset_field(str)
     vec = pvector_field(str)
+
+
+class UniqueThing(PClass):
+    id = field(type=uuid.UUID, factory=uuid.UUID)
 
 
 def test_evolve_pclass_instance():
@@ -401,3 +406,7 @@ def test_enum_key_type():
         f = pmap_field(key_type=(Foo,), value_type=int)
 
     MyClass2()
+
+def test_pickle_with_one_way_factory():
+    thing = UniqueThing(id='25544626-86da-4bce-b6b6-9186c0804d64')
+    assert pickle.loads(pickle.dumps(thing)) == thing

--- a/tests/record_test.py
+++ b/tests/record_test.py
@@ -2,6 +2,7 @@ import pickle
 import datetime
 import pytest
 import six
+import uuid
 from pyrsistent import (
     PRecord, field, InvariantException, ny, pset, PSet, CheckedPVector,
     PTypeError, pset_field, pvector_field, pmap_field, pmap, PMap,
@@ -17,6 +18,10 @@ class RecordContainingContainers(PRecord):
     map = pmap_field(str, str)
     vec = pvector_field(str)
     set = pset_field(str)
+
+
+class UniqueThing(PRecord):
+    id = field(type=uuid.UUID, factory=uuid.UUID)
 
 
 def test_create():
@@ -768,3 +773,10 @@ def test_supports_lazy_initial_value_for_field():
         a = field(int, initial=lambda: 2)
 
     assert MyRecord() == MyRecord(a=2)
+
+def test_pickle_with_one_way_factory():
+    """
+    A field factory isn't called when restoring from pickle.
+    """
+    thing = UniqueThing(id='25544626-86da-4bce-b6b6-9186c0804d64')
+    assert thing == pickle.loads(pickle.dumps(thing))


### PR DESCRIPTION
Subclasses of PRecord and PClass can have fields with factory functions,
but if we are loading a pickled instance then the values should have
already gone through the factory and we can (and perhaps need to) safely
bypass them.