### PR TITLE
Fix negative indexing for pdeques.

### DIFF
--- a/pyrsistent/_pdeque.py
+++ b/pyrsistent/_pdeque.py
@@ -334,7 +334,12 @@ class PDeque(object):
         if index >= 0:
             return self.popleft(index).left
 
-        return  self.pop(index).right
+        shifted = len(self) + index
+        if shifted < 0:
+            raise IndexError(
+                "pdeque index {0} out of range {1}".format(index, len(self)),
+            )
+        return self.popleft(shifted).left
 
     index = Sequence.index
 

--- a/tests/deque_test.py
+++ b/tests/deque_test.py
@@ -226,7 +226,20 @@ def test_pickling():
 def test_indexing():
     assert pdeque([1, 2, 3])[0] == 1
     assert pdeque([1, 2, 3])[1] == 2
+    assert pdeque([1, 2, 3])[2] == 3
     assert pdeque([1, 2, 3])[-1] == 3
+    assert pdeque([1, 2, 3])[-2] == 2
+    assert pdeque([1, 2, 3])[-3] == 1
+
+
+def test_one_element_indexing():
+    assert pdeque([2])[0] == 2
+    assert pdeque([2])[-1] == 2
+
+
+def test_empty_indexing():
+    with pytest.raises(IndexError):
+        assert pdeque([])[0] == 1
 
 
 def test_indexing_out_of_range():
@@ -235,6 +248,9 @@ def test_indexing_out_of_range():
 
     with pytest.raises(IndexError):
         pdeque([1, 2, 3])[3]
+
+    with pytest.raises(IndexError):
+        pdeque([2])[-2]
 
 
 def test_indexing_invalid_type():


### PR DESCRIPTION
Previously, deques would improperly claim to be empty.

3 of the new tests I added here were failing before the patch.

I'm sure there's actually a shorter implementation that passes all these tests, but it would require changing some of the rest of pdeque's internals, which seemed like a bit of work that's tangled with other stuff here.