### PR TITLE
Ensure that all types can be constructed with iterables.

### DIFF
--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -378,7 +378,16 @@ Hashable.register(PMap)
 
 
 def _turbo_mapping(initial, pre_size):
-    size = pre_size or (2 * len(initial)) or 8
+    if pre_size:
+        size = pre_size
+    else:
+        try:
+            size = 2 * len(initial) or 8
+        except Exception:
+            # Guess we can't figure out the length. Give up on length hinting,
+            # we can always reallocate later.
+            size = 8
+
     buckets = size * [None]
 
     if not isinstance(initial, Mapping):

--- a/tests/bag_test.py
+++ b/tests/bag_test.py
@@ -140,3 +140,11 @@ def test_update():
 def test_update_no_elements():
     b = pbag([1, 2, 2])
     assert b.update([]) is b
+
+
+def test_iterable():
+    """
+    PBags can be created from iterables even though they can't be len() hinted.
+    """
+
+    assert pbag(iter("a")) == pbag(iter("a"))

--- a/tests/deque_test.py
+++ b/tests/deque_test.py
@@ -282,3 +282,12 @@ def test_literalish():
 def test_supports_weakref():
     import weakref
     weakref.ref(dq(1, 2))
+
+
+def test_iterable():
+    """
+    PDeques can be created from iterables even though they can't be len()
+    hinted.
+    """
+
+    assert pdeque(iter("a")) == pdeque(iter("a"))

--- a/tests/list_test.py
+++ b/tests/list_test.py
@@ -198,3 +198,12 @@ def test_supports_weakref():
     import weakref
     weakref.ref(plist())
     weakref.ref(plist([1, 2]))
+
+
+def test_iterable():
+    """
+    PLists can be created from iterables even though they can't be len()
+    hinted.
+    """
+
+    assert plist(iter("a")) == plist(iter("a"))

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -419,3 +419,11 @@ def test_pmap_unorderable():
 def test_supports_weakref():
     import weakref
     weakref.ref(m(a=1))
+
+
+def test_iterable():
+    """
+    PMaps can be created from iterables even though they can't be len() hinted.
+    """
+
+    assert pmap(iter([("a", "b")])) == pmap([("a", "b")])

--- a/tests/set_test.py
+++ b/tests/set_test.py
@@ -168,3 +168,11 @@ def test_update():
 def test_update_no_elements():
     s1 = s(1, 2)
     assert s1.update([]) is s1
+
+
+def test_iterable():
+    """
+    PSets can be created from iterables even though they can't be len() hinted.
+    """
+
+    assert pset(iter("a")) == pset(iter("a"))

--- a/tests/vector_test.py
+++ b/tests/vector_test.py
@@ -907,3 +907,12 @@ def test_failing_repr(pvector):
 
     with pytest.raises(ValueError):
         repr(pvector([A()]))
+
+
+def test_iterable(pvector):
+    """
+    PVectors can be created from iterables even though they can't be len()
+    hinted.
+    """
+
+    assert pvector(iter("a")) == pvector(iter("a"))


### PR DESCRIPTION
Fixes PMap, closing #117.

Threw in tests for all of the datatypes I believe. Some of these were partially covered in other test cases but seems convenient to have a test dedicated to this that's the same across all of them.