### PR TITLE
Fix PClass double-factory-ing in a few situations.

### DIFF
--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -96,6 +96,10 @@ class PClass(CheckedType):
         """
         if args:
             kwargs[args[0]] = args[1]
+        for key, value in kwargs.items():
+            field = self._pclass_fields.get(key)
+            if field is not None:
+                value = field.factory(value)
 
         for key in self._pclass_fields:
             if key not in kwargs:
@@ -103,7 +107,7 @@ class PClass(CheckedType):
                 if value is not _MISSING_VALUE:
                     kwargs[key] = value
 
-        return self.__class__(**kwargs)
+        return self.__class__(_bypass_factories=True, **kwargs)
 
     @classmethod
     def create(cls, kwargs, _bypass_factories=False):
@@ -211,6 +215,9 @@ class _PClassEvolver(object):
 
     def set(self, key, value):
         if self._pclass_evolver_data.get(key, _MISSING_VALUE) is not value:
+            field = self._pclass_evolver_original._pclass_fields.get(key)
+            if field is not None:
+                value = field.factory(value)
             self._pclass_evolver_data[key] = value
             self._pclass_evolver_data_is_dirty = True
 
@@ -232,7 +239,8 @@ class _PClassEvolver(object):
 
     def persistent(self):
         if self._pclass_evolver_data_is_dirty:
-            return self._pclass_evolver_original.__class__(**self._pclass_evolver_data)
+            return self._pclass_evolver_original.__class__(_bypass_factories=True,
+                                                           **self._pclass_evolver_data)
 
         return self._pclass_evolver_original
 

--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -99,7 +99,7 @@ class PClass(CheckedType):
         for key, value in kwargs.items():
             field = self._pclass_fields.get(key)
             if field is not None:
-                value = field.factory(value)
+                kwargs[key] = field.factory(value)
 
         for key in self._pclass_fields:
             if key not in kwargs:

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -421,3 +421,14 @@ def test_evolver_with_one_way_factory():
 def test_set_doesnt_trigger_other_factories():
     thing = UniqueThing(id='b413b280-de76-4e28-a8e3-5470ca83ea2c')
     thing.set(x=5)
+
+def test_set_does_trigger_factories():
+    class SquaredPoint(PClass):
+        x = field(factory=lambda x: x ** 2)
+        y = field()
+
+    sp = SquaredPoint(x=3, y=10)
+    assert (sp.x, sp.y) == (9, 10)
+
+    sp2 = sp.set(x=4)
+    assert (sp2.x, sp2.y) == (16, 10)

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -23,6 +23,7 @@ class TypedContainerObj(PClass):
 
 class UniqueThing(PClass):
     id = field(type=uuid.UUID, factory=uuid.UUID)
+    x = field(type=int)
 
 
 def test_evolve_pclass_instance():
@@ -410,3 +411,13 @@ def test_enum_key_type():
 def test_pickle_with_one_way_factory():
     thing = UniqueThing(id='25544626-86da-4bce-b6b6-9186c0804d64')
     assert pickle.loads(pickle.dumps(thing)) == thing
+
+def test_evolver_with_one_way_factory():
+    thing = UniqueThing(id='cc65249a-56fe-4995-8719-ea02e124b234')
+    ev = thing.evolver()
+    ev.x = 5  # necessary to prevent persistent() returning the original
+    assert ev.persistent() == UniqueThing(id=str(thing.id), x=5)
+
+def test_set_doesnt_trigger_other_factories():
+    thing = UniqueThing(id='b413b280-de76-4e28-a8e3-5470ca83ea2c')
+    thing.set(x=5)


### PR DESCRIPTION
+ After an evolver() -> change -> persistent() cycle, unchanged fields
  from the original PClass get passed through factory functions again.
+ PClass.set() sends all fields through the factories, whether or not it
  is in the **kwargs from the call.