### PR TITLE
Fix regression where type names break sequence fields

### DIFF
--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -3,7 +3,7 @@ import six
 from pyrsistent._checked_types import (
     CheckedType, CheckedPSet, CheckedPMap, CheckedPVector,
     optional as optional_type, InvariantException, get_type, wrap_invariant,
-    _restore_pickle)
+    _restore_pickle, get_type)
 
 
 try:
@@ -159,7 +159,7 @@ def _restore_seq_field_pickle(checked_class, item_type, data):
 
 def _types_to_names(types):
     """Convert a tuple of types to a human-readable string."""
-    return "".join(typ.__name__.capitalize() for typ in types)
+    return "".join(get_type(typ).__name__.capitalize() for typ in types)
 
 def _make_seq_field_type(checked_class, item_type):
     """Create a subclass of the given checked class with the given item type."""

--- a/tests/record_test.py
+++ b/tests/record_test.py
@@ -24,6 +24,12 @@ class UniqueThing(PRecord):
     id = field(type=uuid.UUID, factory=uuid.UUID)
 
 
+class Something(object):
+    pass
+
+class Another(object):
+    pass
+
 def test_create():
     r = ARecord(x=1, y='foo')
     assert r.x == 1
@@ -443,9 +449,6 @@ def test_pset_field_name():
     """
     The created set class name is based on the type of items in the set.
     """
-    class Something(object):
-        pass
-
     class Record(PRecord):
         value = pset_field(Something)
         value2 = pset_field(int)
@@ -458,14 +461,30 @@ def test_pset_multiple_types_field_name():
     The created set class name is based on the multiple given types of
     items in the set.
     """
-    class Something(object):
-        pass
-
     class Record(PRecord):
         value = pset_field((Something, int))
 
     assert (Record().value.__class__.__name__ ==
             "SomethingIntPSet")
+
+def test_pset_field_name_string_type():
+    """
+    The created set class name is based on the type of items specified by name
+    """
+    class Record(PRecord):
+        value = pset_field("record_test.Something")
+    assert Record().value.__class__.__name__ == "SomethingPSet"
+
+
+def test_pset_multiple_string_types_field_name():
+    """
+    The created set class name is based on the multiple given types of
+    items in the set specified by name
+    """
+    class Record(PRecord):
+        value = pset_field(("record_test.Something", "record_test.Another"))
+
+    assert Record().value.__class__.__name__ == "SomethingAnotherPSet"
 
 def test_pvector_field_initial_value():
     """
@@ -566,9 +585,6 @@ def test_pvector_field_name():
     """
     The created set class name is based on the type of items in the set.
     """
-    class Something(object):
-        pass
-
     class Record(PRecord):
         value = pvector_field(Something)
         value2 = pvector_field(int)
@@ -581,14 +597,30 @@ def test_pvector_multiple_types_field_name():
     The created vector class name is based on the multiple given types of
     items in the vector.
     """
-    class Something(object):
-        pass
-
     class Record(PRecord):
         value = pvector_field((Something, int))
 
     assert (Record().value.__class__.__name__ ==
             "SomethingIntPVector")
+
+def test_pvector_field_name_string_type():
+    """
+    The created set class name is based on the type of items in the set
+    specified by name.
+    """
+    class Record(PRecord):
+        value = pvector_field("record_test.Something")
+    assert Record().value.__class__.__name__ == "SomethingPVector"
+
+def test_pvector_multiple_string_types_field_name():
+    """
+    The created vector class name is based on the multiple given types of
+    items in the vector.
+    """
+    class Record(PRecord):
+        value = pvector_field(("record_test.Something", "record_test.Another"))
+
+    assert Record().value.__class__.__name__ == "SomethingAnotherPVector"
 
 def test_pvector_field_create_from_nested_serialized_data():
     class Foo(PRecord):
@@ -703,12 +735,6 @@ def test_pmap_field_name():
     """
     The created map class name is based on the types of items in the map.
     """
-    class Something(object):
-        pass
-
-    class Another(object):
-        pass
-
     class Record(PRecord):
         value = pmap_field(Something, Another)
         value2 = pmap_field(int, float)
@@ -721,18 +747,33 @@ def test_pmap_field_name_multiple_types():
     The created map class name is based on the types of items in the map,
     including when there are multiple supported types.
     """
-    class Something(object):
-        pass
-
-    class Another(object):
-        pass
-
     class Record(PRecord):
         value = pmap_field((Something, Another), int)
         value2 = pmap_field(str, (int, float))
     assert ((Record().value.__class__.__name__,
              Record().value2.__class__.__name__) ==
             ("SomethingAnotherToIntPMap", "StrToIntFloatPMap"))
+
+def test_pmap_field_name_string_type():
+    """
+    The created map class name is based on the types of items in the map
+    specified by name.
+    """
+    class Record(PRecord):
+        value = pmap_field("record_test.Something", "record_test.Another")
+    assert Record().value.__class__.__name__ == "SomethingToAnotherPMap"
+
+def test_pmap_field_name_multiple_string_types():
+    """
+    The created map class name is based on the types of items in the map,
+    including when there are multiple supported types.
+    """
+    class Record(PRecord):
+        value = pmap_field(("record_test.Something", "record_test.Another"), int)
+        value2 = pmap_field(str, ("record_test.Something", "record_test.Another"))
+    assert ((Record().value.__class__.__name__,
+             Record().value2.__class__.__name__) ==
+            ("SomethingAnotherToIntPMap", "StrToSomethingAnotherPMap"))
 
 def test_pmap_field_invariant():
     """


### PR DESCRIPTION
Fix the regression mentioned at the bottom of: https://github.com/tobgu/pyrsistent/issues/48

This:

    my_field = pset_field('my.class.name')

Would fail like this:

    AttributeError: 'str' object has no attribute '__name__'

The reason is that sequence fields did not resolve string names to actual types in `_types_to_names`.

Added tests for pset_field, pvector_field and pmap_field for single and multiple types specified by string.