### PR TITLE
Using the class name to make AttributeError on __getattr__ more informative for PRecords.

### DIFF
--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -91,7 +91,9 @@ class PMap(object):
         try:
             return self[key]
         except KeyError:
-            raise AttributeError("PMap has no attribute '{0}'".format(key))
+            raise AttributeError(
+                "{0} has no attribute '{1}'".format(type(self).__name__, key)
+            )
 
     def iterkeys(self):
         for k, _ in self.iteritems():

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -463,7 +463,10 @@ def test_dot_access_of_non_existing_element_raises_attribute_error():
     with pytest.raises(AttributeError) as error:
         m1.b
 
-    assert "'b'" in str(error.value)
+    error_message = str(error.value)
+
+    assert "'b'" in error_message
+    assert type(m1).__name__ in error_message
 
 
 def test_pmap_unorderable():


### PR DESCRIPTION
This fixes issues with `PRecord` attribute access messages being non-specific, since they use the `PMap` implementation for `getattr`. Now, the error message will tell you the class name of the PRecord you tried to access incorrectly.