### PR TITLE
Fix how fields handle type arguments.

### DIFF
--- a/pyrsistent/_checked_types.py
+++ b/pyrsistent/_checked_types.py
@@ -242,19 +242,19 @@ def optional(*typs):
 
 
 def _checked_type_create(cls, source_data, _factory_fields=None):
-        if isinstance(source_data, cls):
-            return source_data
+    if isinstance(source_data, cls):
+        return source_data
 
-        # Recursively apply create methods of checked types if the types of the supplied data
-        # does not match any of the valid types.
-        types = get_types(cls._checked_types)
-        checked_type = next((t for t in types if issubclass(t, CheckedType)), None)
-        if checked_type:
-            return cls([checked_type.create(data)
-                        if not any(isinstance(data, t) for t in types) else data
-                        for data in source_data])
+    # Recursively apply create methods of checked types if the types of the supplied data
+    # does not match any of the valid types.
+    types = get_types(cls._checked_types)
+    checked_type = next((t for t in types if issubclass(t, CheckedType)), None)
+    if checked_type:
+        return cls([checked_type.create(data)
+                    if not any(isinstance(data, t) for t in types) else data
+                    for data in source_data])
 
-        return cls(source_data)
+    return cls(source_data)
 
 @six.add_metaclass(_CheckedTypeMeta)
 class CheckedPVector(PythonPVector, CheckedType):

--- a/pyrsistent/_compat.py
+++ b/pyrsistent/_compat.py
@@ -1,0 +1,9 @@
+from six import string_types
+
+
+# enum compat
+try:
+    from enum import Enum
+except:
+    class Enum(object): pass
+    # no objects will be instances of this class

--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -1,21 +1,16 @@
 from collections import Iterable
 import six
+
+from pyrsistent._compat import Enum
 from pyrsistent._checked_types import (
     CheckedType, CheckedPSet, CheckedPMap, CheckedPVector,
     optional as optional_type, InvariantException, get_type, wrap_invariant,
     _restore_pickle, get_type)
 
 
-try:
-    from enum import Enum as _Enum
-except:
-    class _Enum(object): pass
-    # no objects will be instances of this class
-
-
 def isenum(type_):
     try:
-        return issubclass(type_, _Enum)
+        return issubclass(type_, Enum)
     except TypeError:
         return False  # type_ is not a class
 

--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -9,8 +9,8 @@ from pyrsistent._checked_types import (
     InvariantException,
     _restore_pickle,
     get_type,
-    maybe_type_to_list,
-    maybe_types_to_list,
+    maybe_parse_user_type,
+    maybe_parse_many_user_types,
 )
 from pyrsistent._checked_types import optional as optional_type
 from pyrsistent._checked_types import wrap_invariant
@@ -89,18 +89,18 @@ def field(type=PFIELD_NO_TYPE, invariant=PFIELD_NO_INVARIANT, initial=PFIELD_NO_
     """
 
     # NB: We have to check this predicate separately from the predicates in
-    # `maybe_type_to_list` et al. because this one is related to supporting the
-    # argspec for `field`, while those are related to supporting the valid ways
-    # to specify types.
+    # `maybe_parse_user_type` et al. because this one is related to supporting
+    # the argspec for `field`, while those are related to supporting the valid
+    # ways to specify types.
 
     # Multiple types must be passed in one of the following containers. Note
     # that a type that is a subclass of one of these containers, like a
     # `collections.namedtuple`, will work as expected, since we check
     # `isinstance` and not `issubclass`.
     if isinstance(type, (list, set, tuple)):
-        types = set(maybe_types_to_list(type))
+        types = set(maybe_parse_many_user_types(type))
     else:
-        types = set(maybe_type_to_list(type))
+        types = set(maybe_parse_user_type(type))
 
     invariant_function = wrap_invariant(invariant) if invariant != PFIELD_NO_INVARIANT and callable(invariant) else invariant
     field = _PField(type=types, invariant=invariant_function, initial=initial,

--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -92,8 +92,12 @@ def field(type=PFIELD_NO_TYPE, invariant=PFIELD_NO_INVARIANT, initial=PFIELD_NO_
     # `maybe_type_to_list` et al. because this one is related to supporting the
     # argspec for `field`, while those are related to supporting the valid ways
     # to specify types.
-    # Multiple types must be passed in a tuple or a list.
-    if isinstance(type, (tuple, list)):
+
+    # Multiple types must be passed in one of the following containers. Note
+    # that a type that is a subclass of one of these containers, like a
+    # `collections.namedtuple`, will work as expected, since we check
+    # `isinstance` and not `issubclass`.
+    if isinstance(type, (list, set, tuple)):
         types = set(maybe_types_to_list(type))
     else:
         types = set(maybe_type_to_list(type))

--- a/tests/field_test.py
+++ b/tests/field_test.py
@@ -3,6 +3,10 @@ from pyrsistent._compat import Enum
 from pyrsistent import field, pvector_field
 
 
+# NB: This derives from the internal `pyrsistent._compat.Enum` in order to
+# simplify coverage across python versions. Since we use
+# `pyrsistent._compat.Enum` in `pyrsistent`'s implementation, it's useful to
+# use it in the test coverage as well, for consistency.
 class TestEnum(Enum):
     x = 1
     y = 2

--- a/tests/field_test.py
+++ b/tests/field_test.py
@@ -1,18 +1,23 @@
-from pyrsistent import field
+from pyrsistent._compat import Enum
+
+from pyrsistent import field, pvector_field
+
+
+class TestEnum(Enum):
+    x = 1
+    y = 2
 
 
 def test_enum():
-    try:
-        from enum import Enum
-    except ImportError:
-        # skip enum test if Enums are not available
-        return
-
-    class TestEnum(Enum):
-        x = 1
-        y = 2
-
     f = field(type=TestEnum)
 
     assert TestEnum in f.type
     assert len(f.type) == 1
+
+
+# This is meant to exercise `_seq_field`.
+def test_pvector_field_enum_type():
+    f = pvector_field(TestEnum)
+
+    assert len(f.type) == 1
+    assert TestEnum is list(f.type)[0].__type__


### PR DESCRIPTION
The immediate issue solved by this is similar to #83 but for `pvector_field` instead of `field`. It also refactors #110 to be more general.

This PR

- defines more clearly the semantics for what sorts of input will be accepted as 'type's in pyrsistent fields;
- extracts that logic from the internals of `_store_types;
- refactors both `field`s and `seq_fields` to use this logic.

Note that this means this logic is actually performed *twice* on `seq_fields`, since they also factor through the `field` constructor. Changing that is out-of-scope, and I think that it's acceptable in any case.

I did not add much coverage since I'm not familiiar with the structure of the project or the test suite, so feel free to comment on that.