### PR TITLE
Fix #137: avoid DeprecationWarning related to collections package imports

### DIFF
--- a/pyrsistent/_checked_types.py
+++ b/pyrsistent/_checked_types.py
@@ -1,4 +1,7 @@
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import six
 
 from pyrsistent._compat import Enum, string_types

--- a/pyrsistent/_checked_types.py
+++ b/pyrsistent/_checked_types.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from ._compat import Iterable
 import six
 
 from pyrsistent._compat import Enum, string_types

--- a/pyrsistent/_compat.py
+++ b/pyrsistent/_compat.py
@@ -7,3 +7,25 @@ try:
 except:
     class Enum(object): pass
     # no objects will be instances of this class
+
+# collections compat
+try:
+    from collections.abc import (
+        Container,
+        Hashable,
+        Iterable,
+        Mapping,
+        Sequence,
+        Set,
+        Sized,
+    )
+except ImportError:
+    from collections import (
+        Container,
+        Hashable,
+        Iterable,
+        Mapping,
+        Sequence,
+        Set,
+        Sized,
+    )

--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -1,4 +1,7 @@
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import six
 
 from pyrsistent._checked_types import (

--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -1,7 +1,3 @@
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 import six
 
 from pyrsistent._checked_types import (

--- a/pyrsistent/_pbag.py
+++ b/pyrsistent/_pbag.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Container, Iterable, Sized, Hashable
-except ImportError:
-    from collections import Container, Iterable, Sized, Hashable
+from ._compat import Container, Iterable, Sized, Hashable
 from functools import reduce
 from pyrsistent._pmap import pmap
 

--- a/pyrsistent/_pbag.py
+++ b/pyrsistent/_pbag.py
@@ -1,4 +1,7 @@
-from collections import Container, Iterable, Sized, Hashable
+try:
+    from collections.abc import Container, Iterable, Sized, Hashable
+except ImportError:
+    from collections import Container, Iterable, Sized, Hashable
 from functools import reduce
 from pyrsistent._pmap import pmap
 

--- a/pyrsistent/_pdeque.py
+++ b/pyrsistent/_pdeque.py
@@ -1,4 +1,7 @@
-from collections import Sequence, Hashable
+try:
+    from collections.abc import Sequence, Hashable
+except ImportError:
+    from collections import Sequence, Hashable
 from itertools import islice, chain
 from numbers import Integral
 from pyrsistent._plist import plist

--- a/pyrsistent/_pdeque.py
+++ b/pyrsistent/_pdeque.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Sequence, Hashable
-except ImportError:
-    from collections import Sequence, Hashable
+from ._compat import Sequence, Hashable
 from itertools import islice, chain
 from numbers import Integral
 from pyrsistent._plist import plist

--- a/pyrsistent/_plist.py
+++ b/pyrsistent/_plist.py
@@ -1,4 +1,7 @@
-from collections import Sequence, Hashable
+try:
+    from collections.abc import Sequence, Hashable
+except ImportError:
+    from collections import Sequence, Hashable
 from numbers import Integral
 from functools import reduce
 

--- a/pyrsistent/_plist.py
+++ b/pyrsistent/_plist.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Sequence, Hashable
-except ImportError:
-    from collections import Sequence, Hashable
+from ._compat import Sequence, Hashable
 from numbers import Integral
 from functools import reduce
 

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Mapping, Hashable
-except ImportError:
-    from collections import Mapping, Hashable
+from ._compat import Mapping, Hashable
 from itertools import chain
 import six
 from pyrsistent._pvector import pvector

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -1,4 +1,7 @@
-from collections import Mapping, Hashable
+try:
+    from collections.abc import Mapping, Hashable
+except ImportError:
+    from collections import Mapping, Hashable
 from itertools import chain
 import six
 from pyrsistent._pvector import pvector

--- a/pyrsistent/_pset.py
+++ b/pyrsistent/_pset.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Set, Hashable
-except ImportError:
-    from collections import Set, Hashable
+from ._compat import Set, Hashable
 import sys
 from pyrsistent._pmap import pmap
 

--- a/pyrsistent/_pset.py
+++ b/pyrsistent/_pset.py
@@ -1,4 +1,7 @@
-from collections import Set, Hashable
+try:
+    from collections.abc import Set, Hashable
+except ImportError:
+    from collections import Set, Hashable
 import sys
 from pyrsistent._pmap import pmap
 

--- a/pyrsistent/_pvector.py
+++ b/pyrsistent/_pvector.py
@@ -1,5 +1,8 @@
 from abc import abstractmethod, ABCMeta
-from collections import Sequence, Hashable
+try:
+    from collections.abc import Sequence, Hashable
+except ImportError:
+    from collections import Sequence, Hashable
 from numbers import Integral
 import operator
 import six

--- a/pyrsistent/_pvector.py
+++ b/pyrsistent/_pvector.py
@@ -1,8 +1,5 @@
 from abc import abstractmethod, ABCMeta
-try:
-    from collections.abc import Sequence, Hashable
-except ImportError:
-    from collections import Sequence, Hashable
+from ._compat import Sequence, Hashable
 from numbers import Integral
 import operator
 import six

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Hashable
-except ImportError:
-    from collections import Hashable
+from pyrsistent._compat import Hashable
 import math
 import pickle
 import pytest

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -1,4 +1,7 @@
-from collections import Hashable
+try:
+    from collections.abc import Hashable
+except ImportError:
+    from collections import Hashable
 import math
 import pickle
 import pytest

--- a/tests/hypothesis_vector_test.py
+++ b/tests/hypothesis_vector_test.py
@@ -4,10 +4,7 @@ Hypothesis-based tests for pvector.
 
 import gc
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from pyrsistent._compat import Iterable
 from functools import wraps
 from pyrsistent import PClass, field
 

--- a/tests/hypothesis_vector_test.py
+++ b/tests/hypothesis_vector_test.py
@@ -4,7 +4,10 @@ Hypothesis-based tests for pvector.
 
 import gc
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from functools import wraps
 from pyrsistent import PClass, field
 

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -1,4 +1,8 @@
-from collections import Mapping, Hashable
+try:
+    from collections.abc import Mapping, Hashable
+except ImportError:
+    from collections import Mapping, Hashable
+import six
 from operator import add
 import pytest
 from pyrsistent import pmap, m, PVector

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Mapping, Hashable
-except ImportError:
-    from collections import Mapping, Hashable
+from pyrsistent._compat import Mapping, Hashable
 import six
 from operator import add
 import pytest

--- a/tests/vector_test.py
+++ b/tests/vector_test.py
@@ -321,10 +321,7 @@ def test_index_error_negative(pvector):
 
 
 def test_is_sequence(pvector):
-    try:
-        from collections.abc import Sequence
-    except ImportError:
-        from collections import Sequence
+    from pyrsistent._compat import Sequence
     assert isinstance(pvector(), Sequence)
 
 
@@ -353,10 +350,7 @@ def test_repr_when_contained_object_contains_reference_to_self(pvector):
 
 
 def test_is_hashable(pvector):
-    try:
-        from collections.abc import Hashable
-    except ImportError:
-        from collections import Hashable
+    from pyrsistent._compat import Hashable
     v = pvector([1, 2, 3])
     v2 = pvector([1, 2, 3])
 

--- a/tests/vector_test.py
+++ b/tests/vector_test.py
@@ -321,7 +321,10 @@ def test_index_error_negative(pvector):
 
 
 def test_is_sequence(pvector):
-    from collections import Sequence
+    try:
+        from collections.abc import Sequence
+    except ImportError:
+        from collections import Sequence
     assert isinstance(pvector(), Sequence)
 
 
@@ -350,7 +353,10 @@ def test_repr_when_contained_object_contains_reference_to_self(pvector):
 
 
 def test_is_hashable(pvector):
-    from collections import Hashable
+    try:
+        from collections.abc import Hashable
+    except ImportError:
+        from collections import Hashable
     v = pvector([1, 2, 3])
     v2 = pvector([1, 2, 3])
 


### PR DESCRIPTION
This PR fix #137.
I also get DeprecationWarning with `Python 3.7` same as #137 as follows:

    pyrsistent/_pmap.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
      from collections import Mapping, Hashable
    pyrsistent/_pmap.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
      from collections import Mapping, Hashable

    pyrsistent/_pvector.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
      from collections import Sequence, Hashable

    pyrsistent/_pset.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
      from collections import Set, Hashable

    pyrsistent/_pbag.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
      from collections import Container, Iterable, Sized, Hashable
    pyrsistent/_pbag.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
      from collections import Container, Iterable, Sized, Hashable
    pyrsistent/_pbag.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
      from collections import Container, Iterable, Sized, Hashable
