### PR TITLE
Resolve #128: Add ignore_extra kwarg on PClass, PRecord create class method

### DIFF
--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -108,13 +108,16 @@ class PClass(CheckedType):
         return self.__class__(_factory_fields=factory_fields, **kwargs)
 
     @classmethod
-    def create(cls, kwargs, _factory_fields=None):
+    def create(cls, kwargs, _factory_fields=None, ignore_extra=False):
         """
         Factory method. Will create a new PClass of the current type and assign the values
         specified in kwargs.
         """
         if isinstance(kwargs, cls):
             return kwargs
+
+        if ignore_extra:
+            kwargs = {k: v for k, v in kwargs.items() if k in cls._pclass_fields}
 
         return cls(_factory_fields=_factory_fields, **kwargs)
 

--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -112,6 +112,9 @@ class PClass(CheckedType):
         """
         Factory method. Will create a new PClass of the current type and assign the values
         specified in kwargs.
+
+        :param ignore_extra: A boolean which when set to True will ignore any keys which appear in kwargs that are not
+                             in the set of fields on the PClass.
         """
         if isinstance(kwargs, cls):
             return kwargs

--- a/pyrsistent/_pclass.py
+++ b/pyrsistent/_pclass.py
@@ -120,7 +120,7 @@ class PClass(CheckedType):
             return kwargs
 
         if ignore_extra:
-            kwargs = {k: v for k, v in kwargs.items() if k in cls._pclass_fields}
+            kwargs = {k: kwargs[k] for k in cls._pclass_fields if k in kwargs}
 
         return cls(_factory_fields=_factory_fields, **kwargs)
 

--- a/pyrsistent/_precord.py
+++ b/pyrsistent/_precord.py
@@ -81,6 +81,9 @@ class PRecord(PMap, CheckedType):
         """
         Factory method. Will create a new PRecord of the current type and assign the values
         specified in kwargs.
+
+        :param ignore_extra: A boolean which when set to True will ignore any keys which appear in kwargs that are not
+                             in the set of fields on the PRecord.
         """
         if isinstance(kwargs, cls):
             return kwargs

--- a/pyrsistent/_precord.py
+++ b/pyrsistent/_precord.py
@@ -77,13 +77,16 @@ class PRecord(PMap, CheckedType):
                                  ', '.join('{0}={1}'.format(k, repr(v)) for k, v in self.items()))
 
     @classmethod
-    def create(cls, kwargs, _factory_fields=None):
+    def create(cls, kwargs, _factory_fields=None, ignore_extra=False):
         """
         Factory method. Will create a new PRecord of the current type and assign the values
         specified in kwargs.
         """
         if isinstance(kwargs, cls):
             return kwargs
+
+        if ignore_extra:
+            kwargs = {k: v for k, v in kwargs.items() if k in cls._precord_fields}
 
         return cls(_factory_fields=_factory_fields, **kwargs)
 

--- a/pyrsistent/_precord.py
+++ b/pyrsistent/_precord.py
@@ -89,7 +89,7 @@ class PRecord(PMap, CheckedType):
             return kwargs
 
         if ignore_extra:
-            kwargs = {k: v for k, v in kwargs.items() if k in cls._precord_fields}
+            kwargs = {k: kwargs[k] for k in cls._precord_fields if k in kwargs}
 
         return cls(_factory_fields=_factory_fields, **kwargs)
 

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -26,6 +26,19 @@ class UniqueThing(PClass):
     x = field(type=int)
 
 
+def test_create_ignore_extra():
+    p = Point.create({'x': 5, 'y': 10, 'z': 15, 'a': 0}, ignore_extra=True)
+    assert p.x == 5
+    assert p.y == 10
+    assert p.z == 15
+    assert isinstance(p, Point)
+
+
+def test_create_ignore_extra_false():
+    with pytest.raises(AttributeError):
+        _ = Point.create({'x': 5, 'y': 10, 'z': 15, 'a': 0})
+
+
 def test_evolve_pclass_instance():
     p = Point(x=1, y=2)
     p2 = p.set(x=p.x+2)

--- a/tests/record_test.py
+++ b/tests/record_test.py
@@ -37,6 +37,18 @@ def test_create():
     assert isinstance(r, ARecord)
 
 
+def test_create_ignore_extra():
+    r = ARecord.create({'x': 1, 'y': 'foo', 'z': None}, ignore_extra=True)
+    assert r.x == 1
+    assert r.y == 'foo'
+    assert isinstance(r, ARecord)
+
+
+def test_create_ignore_extra_false():
+    with pytest.raises(AttributeError):
+        _ = ARecord.create({'x': 1, 'y': 'foo', 'z': None})
+
+
 def test_correct_assignment():
     r = ARecord(x=1, y='foo')
     r2 = r.set('x', 2.0)


### PR DESCRIPTION
Added this optional argument and made it False by default for backwards compatibility.