### PR TITLE
Only require pytest-runner if running tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ psutil==2.1.1
 tox
 six
 pyperform
-hypothesis<=2.0.0
+hypothesis<4.0.0

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     test_suite='tests',
-    tests_require=['pytest','hypothesis<=2.0.0'],
+    tests_require=['pytest','hypothesis<4.0.0'],
     scripts=[],
     setup_requires=pytest_runner,
     ext_modules=extensions,

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     test_suite='tests',
-    tests_require=['pytest','hypothesis'],
+    tests_require=['pytest','hypothesis<=2.0.0'],
     scripts=[],
     setup_requires=pytest_runner,
     ext_modules=extensions,

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ extensions = []
 if platform.python_implementation() == 'CPython':
     extensions = [Extension('pvectorc', sources=['pvectorcmodule.c'])]
 
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
+
 
 class custom_build_ext(build_ext):
     """Allow C extension building to fail."""
@@ -79,7 +82,7 @@ setup(
     test_suite='tests',
     tests_require=['pytest','hypothesis'],
     scripts=[],
-    setup_requires=['pytest-runner'],
+    setup_requires=pytest_runner,
     ext_modules=extensions,
     cmdclass={'build_ext': custom_build_ext},
     install_requires=['six'],


### PR DESCRIPTION
Having pytest-runner in setup_requires forces us to always install this to run setup.py. This is problematic for two reasons:

1) It's only needed for running the tests, so we don't really want to install this for non-development cases.

2) If installing the package through pip, setup_requires is handed off to easy_install - however, this means it then ignores any pip configuration (so is problematic for using custom indexes or networking configuration).