### PR TITLE
Added FileNotFoundError to custom_build_ext.run().

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ WARNING: Could not build the %s.
     def run(self):
         try:
             build_ext.run(self)
-        except (CCompilerError, DistutilsExecError, DistutilsPlatformError):
+        except (CCompilerError, DistutilsExecError, DistutilsPlatformError, FileNotFoundError):
             e = sys.exc_info()[1]
             sys.stdout.write('%s\n' % str(e))
             warnings.warn(self.warning_message % ("Extension modules",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ WARNING: Could not build the %s.
         name = ext.name
         try:
             build_ext.build_extension(self, ext)
-        except (CCompilerError, DistutilsExecError, DistutilsPlatformError):
+        except (CCompilerError, DistutilsExecError, DistutilsPlatformError, FileNotFoundError):
             e = sys.exc_info()[1]
             sys.stdout.write('%s\n' % str(e))
             warnings.warn(self.warning_message % ("The %s extension "


### PR DESCRIPTION
This pull request adds `FileNotFoundError` to the `except` list in setup.py after verifying that it fixed the installation problems on the test machine, which was Windows Server 2012 R2.

Fixes issue #161.