### PR TITLE
setup.py: Define FileNotFoundError as IOError on Py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,11 @@ from distutils.errors import CCompilerError
 from distutils.errors import DistutilsPlatformError, DistutilsExecError
 from _pyrsistent_version import __version__
 
+try:
+    FileNotFoundError
+except NameError:  # Python 2
+    FileNotFoundError = IOError
+
 
 readme_path = os.path.join(os.path.dirname(__file__), 'README.rst')
 with codecs.open(readme_path, encoding='utf8') as f:


### PR DESCRIPTION
Fixes #163

FileNotFoundError doesn't exist on Python 2.7.
Its equivalent would be IOError in this context.
Should fix build on Python 2.7