### PR TITLE
Ss18/pr1 typos

### DIFF
--- a/pyrsistent/_checked_types.py
+++ b/pyrsistent/_checked_types.py
@@ -117,7 +117,7 @@ def _merge_invariant_results(result):
 
 def wrap_invariant(invariant):
     # Invariant functions may return the outcome of several tests
-    # In those cases the results have to be merged before beeing passed
+    # In those cases the results have to be merged before being passed
     # back to the client.
     def f(*args, **kwargs):
         result = invariant(*args, **kwargs)

--- a/tests/performance_run.py
+++ b/tests/performance_run.py
@@ -299,7 +299,7 @@ def run_multiple_inserts_in_pmap():
     # Using ordinary set
     start = time.time()
     m1 = pmap(elements)
-    print("Done initalizing, time=%s s, count=%s" % (time.time() - start, COUNT))
+    print("Done initializing, time=%s s, count=%s" % (time.time() - start, COUNT))
 
 
     start = time.time()


### PR DESCRIPTION
Fixed typos:

beeing - > being
initalizing -> initializing

Found with: https://github.com/ss18/grep-typos