### PR TITLE
Fix a GC traversal bug.

### DIFF
--- a/pvectorcmodule.c
+++ b/pvectorcmodule.c
@@ -1557,7 +1557,9 @@ static PyObject* PVectorEvolver_is_dirty(PVectorEvolver *self) {
 
 static int PVectorEvolver_traverse(PVectorEvolver *self, visitproc visit, void *arg) {
   Py_VISIT(self->newVector);
-  Py_VISIT(self->originalVector);
+  if (self->newVector != self->originalVector) {
+      Py_VISIT(self->originalVector);
+  }
   Py_VISIT(self->appendList);
   return 0;
 }

--- a/tests/vector_test.py
+++ b/tests/vector_test.py
@@ -903,6 +903,17 @@ def test_supports_weakref(pvector):
     import weakref
     weakref.ref(pvector())
 
+def test_get_evolver_referents(pvector):
+    """The C implementation of the evolver should expose the original PVector
+    to the gc only once.
+    """
+    if pvector.__module__ == 'pyrsistent._pvector':
+        pytest.skip("This test only applies to pvectorc")
+    import gc
+    v = pvector([1, 2, 3])
+    e = v.evolver()
+    assert len([x for x in gc.get_referents(e) if x is v]) == 1
+
 
 def test_failing_repr(pvector):
     # See https://github.com/tobgu/pyrsistent/issues/84


### PR DESCRIPTION
We ran into an issue in production  where the GC would decrement the ref_cnt of a pvector below 0 (`gcmodule.c:366: visit_decref: Assertion 'gc->gc.gc_refs != 0'`). This would happen on the second PyVisit of a PVectorEvolver where `self->newVector != self->originalVector`.
Sadly I was not able to come up with a minimal reproducible test case.