### PR TITLE
Set absolute_import for python2 compatibility.

### DIFF
--- a/pyrsistent/typing.py
+++ b/pyrsistent/typing.py
@@ -11,6 +11,7 @@ For example,
     myvector: PVector[str] = pvector(['a', 'b', 'c'])
 
 """
+from __future__ import absolute_import
 
 try:
     from typing import Container


### PR DESCRIPTION
Purpose: permit to use symbols defined in this module within python2.

Tested with [typing 3.7.4.1](https://pypi.org/project/typing/).