### PR TITLE
Include LICENSE file in packaged distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     author_email='tobias.l.gustafsson@gmail.com',
     url='http://github.com/tobgu/pyrsistent/',
     license='MIT',
+    license_files=['LICENCE.mit'],
     py_modules=['_pyrsistent_version'],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Currently [pip-licenses](https://github.com/raimon49/pip-licenses) can't include the LICENSE file for this project because the correct metadata is not setup.

This PR sets up the metadata correctly so the LICENSE file is properly included/linked to in source and wheel distributions.