### PR TITLE
Fixed 'ignore_extra' for 'pvector_field'

### DIFF
--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -225,11 +225,11 @@ def _sequence_field(checked_class, item_type, optional, initial):
     TheType = _make_seq_field_type(checked_class, item_type)
 
     if optional:
-        def factory(argument):
+        def factory(argument, _factory_fields=None, ignore_extra=False):
             if argument is None:
                 return None
             else:
-                return TheType.create(argument)
+                return TheType.create(argument, _factory_fields=_factory_fields, ignore_extra=ignore_extra)
     else:
         factory = TheType.create
 

--- a/tests/record_test.py
+++ b/tests/record_test.py
@@ -58,6 +58,21 @@ def test_create_ignore_extra_true_sequence_hierarchy():
     assert h
 
 
+def test_ignore_extra_for_pvector_field():
+    class HierarchyA(PRecord):
+        points = pvector_field(ARecord, optional=False)
+
+    class HierarchyB(PRecord):
+        points = pvector_field(ARecord, optional=True)
+
+    point_object = {'x': 1, 'y': 'foo', 'extra_field': 69}
+
+    h = HierarchyA.create({'points': [point_object]}, ignore_extra=True)
+    assert h
+    h = HierarchyB.create({'points': [point_object]}, ignore_extra=True)
+    assert h
+
+
 def test_create():
     r = ARecord(x=1, y='foo')
     assert r.x == 1


### PR DESCRIPTION
Fixed factory for 'sequence_field' with 'optional' parameter 'True' (support of '_factory_fields' and 'ignore_extra' params)