### PR TITLE
Fix exception causes

### DIFF
--- a/pyrsistent/_immutable.py
+++ b/pyrsistent/_immutable.py
@@ -98,6 +98,6 @@ class {class_name}(namedtuple('ImmutableBase', [{quoted_members}]{verbose_string
     try:
         exec(template, namespace)
     except SyntaxError as e:
-        raise SyntaxError(e.message + ':\n' + template)
+        raise SyntaxError(e.message + ':\n' + template) from e
 
     return namespace[name]

--- a/pyrsistent/_pdeque.py
+++ b/pyrsistent/_pdeque.py
@@ -276,8 +276,8 @@ class PDeque(object):
                 # This is severely inefficient with a double reverse, should perhaps implement a remove_last()?
                 return PDeque(self._left_list,
                                self._right_list.reverse().remove(elem).reverse(), self._length - 1)
-            except ValueError:
-                raise ValueError('{0} not found in PDeque'.format(elem))
+            except ValueError as e:
+                raise ValueError('{0} not found in PDeque'.format(elem)) from e
 
     def reverse(self):
         """

--- a/pyrsistent/_plist.py
+++ b/pyrsistent/_plist.py
@@ -179,8 +179,8 @@ class _PListBase(object):
 
         try:
             return self._drop(index).first
-        except AttributeError:
-            raise IndexError("PList index out of range")
+        except AttributeError as e:
+            raise IndexError("PList index out of range") from e
 
     def _drop(self, count):
         if count < 0:

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -92,10 +92,10 @@ class PMap(object):
     def __getattr__(self, key):
         try:
             return self[key]
-        except KeyError:
+        except KeyError as e:
             raise AttributeError(
                 "{0} has no attribute '{1}'".format(type(self).__name__, key)
-            )
+            ) from e
 
     def iterkeys(self):
         for k, _ in self.iteritems():


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used.

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 