### PR TITLE
adjust pmap_field invariant type signature

### DIFF
--- a/pyrsistent/__init__.pyi
+++ b/pyrsistent/__init__.pyi
@@ -97,14 +97,14 @@ def pmap_field(
     key_type: Type[KT],
     value_type: Type[VT],
     optional: bool = False,
-    invariant: Callable[[Any], Tuple[bool, Optional[str]]] = lambda _: (True, None),
+    invariant: Callable[[KT, VT], Tuple[bool, Optional[str]]] = lambda _1, _2: (True, None),
 ) -> PMap[KT, VT]: ...
 @overload
 def pmap_field(
     key_type: Any,
     value_type: Any,
     optional: bool = False,
-    invariant: Callable[[Any], Tuple[bool, Optional[str]]] = lambda _: (True, None),
+    invariant: Callable[[Any, Any], Tuple[bool, Optional[str]]] = lambda _1, _2: (True, None),
 ) -> PMap[Any, Any]: ...
 
 @overload


### PR DESCRIPTION
it appears that `pmap_field` expects k and v as arguments to the lambda defining the invariant? if so, this PR adjusts the type signature.
The documentation for `pmap_field` stating that invariant is "Pass-through to `field`" should also perhaps be adjusted