### PR TITLE
Add python_requires='>=3.5' to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,4 +78,5 @@ setup(
     cmdclass={'build_ext': custom_build_ext},
     packages=['pyrsistent'],
     package_data={'pyrsistent': ['py.typed', '__init__.pyi', 'typing.pyi']},
+    python_requires='>=3.5',
 )


### PR DESCRIPTION
See #205 

This strictly enforces the requirements for Python >=3.5.

After the merge+release, still needs a yank of the 0.17.0 release to make the Python2.7 ecosystem "safe" again :) .