### PR TITLE
Add check for hash when matching pmap keys, fixes #212

### DIFF
--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -61,7 +61,7 @@ class PMap(object):
         _, bucket = PMap._get_bucket(buckets, key)
         if bucket:
             for k, v in bucket:
-                if k == key:
+                if k == key and hash(k) == hash(key):
                     return v
 
         raise KeyError(key)
@@ -74,7 +74,7 @@ class PMap(object):
         _, bucket = PMap._get_bucket(buckets, key)
         if bucket:
             for k, _ in bucket:
-                if k == key:
+                if k == key and hash(k) == hash(key):
                     return True
 
             return False
@@ -301,7 +301,7 @@ class PMap(object):
             index, bucket = PMap._get_bucket(self._buckets_evolver, key)
             if bucket:
                 for k, v in bucket:
-                    if k == key:
+                    if k == key and hash(k) == hash(key):
                         if v is not val:
                             new_bucket = [(k2, v2) if k2 != k else (k2, val) for k2, v2 in bucket]
                             self._buckets_evolver[index] = new_bucket

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -318,6 +318,31 @@ def test_hash_collision_is_correctly_resolved():
     assert empty_map.discard(dummy1) is empty_map
 
 
+class ObjectHashButAlwaysEqual(object):
+    def __hash__(self):
+        return object.__hash__(self)
+
+    def __eq__(self, other):
+        return True
+
+
+def test_object_hash_but_always_equal():
+    keys = []
+    py_dict = {}
+    for i in range(10000):
+        key = ObjectHashButAlwaysEqual()
+        keys.append(key)
+        py_dict[key] = i
+
+    p_map = pmap(py_dict)
+    assert len(py_dict) == len(p_map)
+    assert set(py_dict.keys()) == set(p_map.keys())
+
+    for i, key in enumerate(keys):
+        assert py_dict[key] == i
+        assert p_map[key] == i
+
+
 def test_bitmap_indexed_iteration():
     map = pmap({'a': 2, 'b': 1})
     keys = set()


### PR DESCRIPTION
Just a suggestion. Would this be a valid fix? I'm thinking the key needs to be matched by equality and hash, so we mimic the behaviour of the native dictionary.