### PR TITLE
Add union operator to persistent map

### DIFF
--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -244,6 +244,8 @@ class PMap(object):
     def __add__(self, other):
         return self.update(other)
 
+    __or__ = __add__
+
     def __reduce__(self):
         # Pickling support
         return pmap, (dict(self),)

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -243,6 +243,8 @@ def test_update_no_arguments():
 def test_addition():
     assert m(x=1, y=2) + m(y=3, z=4) == m(x=1, y=3, z=4)
 
+def test_union_operator():
+    assert m(x=1, y=2) | m(y=3, z=4) == m(x=1, y=3, z=4)
 
 def test_transform_base_case():
     # Works as set when called with only one key


### PR DESCRIPTION
#211 

This adds the `__or__` method. That by itself should be fairly straight forward.

One thing I am unclear about is what the preferred behavior for interacting with regular dicts should be. PEP 538 has this listed as an approximate reference implementation.

```python
def __or__(self, other):
    if not isinstance(other, dict):
        return NotImplemented
    new = dict(self)
    new.update(other)
    return new

def __ror__(self, other):
    if not isinstance(other, dict):
        return NotImplemented
    new = dict(other)
    new.update(self)
    return new

def __ior__(self, other):
    dict.update(self, other)
    return self
```

Should `__ror__` be implemented as well?