### PR TITLE
Preallocate pmap according to PRecord fields count

### DIFF
--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -445,7 +445,7 @@ def pmap(initial={}, pre_size=0):
     >>> pmap({'a': 13, 'b': 14})
     pmap({'b': 14, 'a': 13})
     """
-    if not initial:
+    if not initial and pre_size == 0:
         return _EMPTY_PMAP
 
     return _turbo_mapping(initial, pre_size)

--- a/pyrsistent/_precord.py
+++ b/pyrsistent/_precord.py
@@ -46,7 +46,7 @@ class PRecord(PMap, CheckedType, metaclass=_PRecordMeta):
                                   for k, v in cls._precord_initial_values.items())
             initial_values.update(kwargs)
 
-        e = _PRecordEvolver(cls, pmap(), _factory_fields=factory_fields, _ignore_extra=ignore_extra)
+        e = _PRecordEvolver(cls, pmap(pre_size=len(cls._precord_fields)), _factory_fields=factory_fields, _ignore_extra=ignore_extra)
         for k, v in initial_values.items():
             e[k] = v
 


### PR DESCRIPTION
Since the fields in a `PRecord` is fixed, the total size of the `PMap` in the record is already known before allocating the map. We can use the length of `_precord_fields` to pre-allocate the map to avoid reallocating later.

For example, if we add a log in `_reallocate` and give the following test code:

```python
from pyrsistent import field
from pyrsistent import PRecord


class DRecord(PRecord):
    a = field()
    b = field()
    c = field()
    d = field()
    e = field()
    f = field()
    g = field()
    h = field()
    i = field()
    j = field()
    k = field()
    m = field()
    n = field()
    o = field()
    p = field()
    q = field()


r = DRecord()
for k in ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "m", "n", "o", "p", "q"]:
    r = r.set(k, 1)
    print(r)
```

Without the pre-allocating, the output will be:

```bash
DRecord(a=1)
DRecord(b=1, a=1)
DRecord(c=1, b=1, a=1)
DRecord(c=1, b=1, d=1, a=1)
DRecord(c=1, b=1, e=1, d=1, a=1)
DRecord(f=1, c=1, b=1, e=1, d=1, a=1)
DRecord(f=1, c=1, g=1, b=1, e=1, d=1, a=1)
DRecord(f=1, c=1, g=1, b=1, h=1, e=1, d=1, a=1)
DRecord(f=1, c=1, g=1, i=1, b=1, h=1, e=1, d=1, a=1)
DRecord(f=1, c=1, g=1, i=1, b=1, j=1, h=1, e=1, d=1, a=1)
DRecord(f=1, c=1, g=1, i=1, b=1, k=1, j=1, h=1, e=1, d=1, a=1)
DRecord(f=1, c=1, g=1, i=1, b=1, k=1, j=1, h=1, e=1, d=1, a=1, m=1)
_reallocate
DRecord(g=1, i=1, b=1, h=1, d=1, a=1, n=1, f=1, c=1, k=1, j=1, e=1, m=1)
DRecord(g=1, i=1, b=1, h=1, d=1, a=1, n=1, f=1, c=1, k=1, j=1, e=1, o=1, m=1)
DRecord(g=1, i=1, b=1, p=1, h=1, d=1, a=1, n=1, f=1, c=1, k=1, j=1, e=1, o=1, m=1)
DRecord(g=1, i=1, b=1, p=1, h=1, d=1, a=1, q=1, n=1, f=1, c=1, k=1, j=1, e=1, o=1, m=1)
```

And with the pre-allocating, the reallocating is avoided:

```bash
DRecord(a=1)
DRecord(a=1, b=1)
DRecord(c=1, a=1, b=1)
DRecord(c=1, a=1, b=1, d=1)
DRecord(c=1, a=1, b=1, d=1, e=1)
DRecord(c=1, a=1, b=1, d=1, f=1, e=1)
DRecord(c=1, a=1, b=1, d=1, f=1, e=1, g=1)
DRecord(c=1, a=1, b=1, d=1, f=1, e=1, h=1, g=1)
DRecord(i=1, c=1, a=1, b=1, d=1, f=1, e=1, h=1, g=1)
DRecord(i=1, c=1, a=1, b=1, d=1, f=1, e=1, h=1, j=1, g=1)
DRecord(i=1, c=1, a=1, b=1, d=1, k=1, f=1, e=1, h=1, j=1, g=1)
DRecord(i=1, c=1, a=1, b=1, d=1, k=1, m=1, f=1, e=1, h=1, j=1, g=1)
DRecord(i=1, c=1, a=1, b=1, d=1, k=1, m=1, f=1, n=1, e=1, h=1, j=1, g=1)
DRecord(i=1, c=1, a=1, b=1, d=1, k=1, m=1, f=1, n=1, e=1, h=1, j=1, g=1, o=1)
DRecord(i=1, c=1, a=1, b=1, d=1, k=1, m=1, f=1, n=1, e=1, p=1, h=1, j=1, g=1, o=1)
DRecord(i=1, c=1, q=1, a=1, b=1, d=1, k=1, m=1, f=1, n=1, e=1, p=1, h=1, j=1, g=1, o=1)
```