### PR TITLE
LICENCE.mit => LICENSE.mit in setup.py and MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include *.rst
 include tests/*_test.py
 include tests/memory_profiling.py
 include CHANGES.txt
-include LICENCE.mit
+include LICENSE.mit

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     author_email='tobias.l.gustafsson@gmail.com',
     url='http://github.com/tobgu/pyrsistent/',
     license='MIT',
-    license_files=['LICENCE.mit'],
+    license_files=['LICENSE.mit'],
     py_modules=['_pyrsistent_version'],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Over in https://github.com/tobgu/pyrsistent/pull/217 the license file was renamed from `LICENCE.mit` into `LICENSE.mit`, however the PR forgot to update `setup.py` and `MANIFEST.in` accordingly. This PR fixes that issue! :+1:

--
Background info: I noticed this when running `make vendor/sync` in the root of https://github.com/python-poetry/poetry-core, which currently errors with:
```
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://raw.githubusercontent.com/tobgu/pyrsistent/master/LICENCE.mit
make: *** [vendor/sync] Error 1`.
```