### PR TITLE
Fix KeyError obscured by TypeError if key is a tuple

### DIFF
--- a/pyrsistent/_pset.py
+++ b/pyrsistent/_pset.py
@@ -96,7 +96,7 @@ class PSet(object):
         if element in self._map:
             return self.evolver().remove(element).persistent()
 
-        raise KeyError("Element '%s' not present in PSet" % element)
+        raise KeyError("Element '%s' not present in PSet" % repr(element))
 
     def discard(self, element):
         """

--- a/tests/set_test.py
+++ b/tests/set_test.py
@@ -2,6 +2,9 @@ from pyrsistent import pset, s
 import pytest
 import pickle
 
+def test_key_is_tuple():
+    with pytest.raises(KeyError):
+        pset().remove((1,1))
 
 def test_literalish_works():
     assert s() is pset()


### PR DESCRIPTION
If element is a tuple % tries to unpack the tuple and the argument-count can be
wrong. Getting the repr of the element converts it to a string and therefore a
single argument.