### PR TITLE
Fix typo in docstring for "m"

### DIFF
--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -453,7 +453,7 @@ def pmap(initial={}, pre_size=0):
 
 def m(**kwargs):
     """
-    Creates a new persitent map. Inserts all key value arguments into the newly created map.
+    Creates a new persistent map. Inserts all key value arguments into the newly created map.
 
     >>> m(a=13, b=14)
     pmap({'b': 14, 'a': 13})


### PR DESCRIPTION
This PR simply fixes a typo in a docstring, replacing "persitent" with "persistent". I did grep through the sources for other occurrences of this particular typo, and didn't find any other matches for either "persit" or "pyrsit".