### PR TITLE
Stop using exception.message

### DIFF
--- a/pyrsistent/_immutable.py
+++ b/pyrsistent/_immutable.py
@@ -98,6 +98,6 @@ class {class_name}(namedtuple('ImmutableBase', [{quoted_members}]{verbose_string
     try:
         exec(template, namespace)
     except SyntaxError as e:
-        raise SyntaxError(e.message + ':\n' + template) from e
+        raise SyntaxError(str(e) + ':\n' + template) from e
 
     return namespace[name]


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1713825#c0

> In PEP 352, exception.message was deprecated (now, you can get the string from of an exception by simply doing str(exception). As of Python 3.0, exception.message was dropped, and attempting to access it causes an error.