### PR TITLE
Add support for building macOS universal2 wheels in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,28 @@ jobs:
           - os: macos-latest
             bitness: 64
             platform_id: macosx_x86_64
+          - os: macos-latest
+            bitness: 64
+            platform_id: macosx_universal2
+          # Python 3.6 and 3.7 did not have universal2 wheel support yet
+          - os: macos-latest
+            python: 36
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 37
+            platform_id: macosx_x86_64
+          # Python 3.8 and onwards only need universal2 wheels
+          - os: macos-latest
+            python: 38
+            platform_id: macosx_universal2
+          - os: macos-latest
+            python: 39
+            platform_id: macosx_universal2
         exclude:
           - os: macos-latest
             bitness: 32
     env:
+      CIBW_ARCHS_MACOS: x86_64 universal2
       CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
       CIBW_TEST_REQUIRES: pytest==4.* hypothesis==4.*
       CIBW_TEST_COMMAND: "bash {project}/tools/test_wheels.sh {project}"
@@ -54,7 +72,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v1.11.1.post1
+        uses: pypa/cibuildwheel@v2.3.1
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This PR adds support for building universal2 wheels on macOS so that the same wheel can be used on Intel and ARM-based Macs.

I had to bump the version of `cibuildwheel` to allow it to build universal2 wheels for Python 3.8. Judging from the `cibuildwheel` changelog, this does not introduce any additional changes to the built wheels; the key differences are:

* Python 2.7 and 3.5 support was dropped in `cibuildwheel` 2.0.0, which does not affect this project.
* Python 3.10 support was added in `cibuildwheel` 2.1.3 (I did not enable Python 3.10 wheels yet, but it would be easy to do now).
* Support for `musllinux` builds was added in `cibuildwheel` 2.2.0, but it has no effect here because each job explicitly enables one configuration in `CIBW_BUILD` and `musllinux` is not included (but it would be easy to do now).
* `manylinux` wheels use the `manylinux2014` image by default from `cibuildwheel` 2.3.0, but it has no effect here either because the `manylinux` Docker images are specified explicitly.