### PR TITLE
Fixes issue #159 and greatly speeds up iteration of PMap in Python3

### DIFF
--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -3,6 +3,68 @@ from itertools import chain
 from pyrsistent._pvector import pvector
 from pyrsistent._transformations import transform
 
+class PMapView(object):
+    """View type for the persistent map/dict type `PMap`.
+
+    Provides an equivalent of Python's built-in `dict_values` and `dict_items`
+    types that result from expreessions such as `{}.values()` and
+    `{}.items()`. The equivalent for `{}.keys()` is absent because the keys are
+    instead represented by a `PSet` object, which can be created in `O(1)` time.
+
+    Parameters
+    ----------
+    m : mapping
+        The mapping/dict-like object of which a view is to be created. This
+        should generally be a `PMap` object.
+    values : boolean, optional
+        If `True`, then a view of the values is created; if `False`, then a view
+        of the items is created.
+    """
+    def __init__(self, m, values=False):
+        # Make sure this is a persistnt map
+        if not isinstance(m, PMap):
+            # We can convert mapping objects into pmap objects, I guess (but why?)
+            if isinstance(m, Mapping):
+                m = pmap(m)
+            else:
+                raise TypeError("PViewMap requires a Mapping object")
+        object.__setattr__(self, '_map', m)
+        object.__setattr__(self, '_values', values)
+    def __len__(self):
+        return len(self._map)
+    def __setattr__(self, k, v):
+        raise TypeError("%s is immutable" % (type(self),))
+    def __iter__(self):
+        if self._values:
+            return self._map.itervalues()
+        else:
+            return self._map.iteritems()
+    def __contains__(self, arg):
+        if self._values:
+            for v in self._map.itervalues():
+                if v == arg: return True
+            return False
+        else:
+            try: (k,v) = arg
+            except Exception: return False
+            m = self._map
+            return k in m and m[k] == v
+    def __reversed__(self):
+        raise TypeError("Persistent maps are not reversible")
+    # The str and repr methods mitate the dict_view style currently.
+    def __str__(self):
+        tag = 'values' if self._values else 'items'
+        return "pmap_%s(%s)" % (tag, list(iter(self)))
+    def __repr__(self):
+        tag = 'values' if self._values else 'items'
+        return "pmap_%s(%s)" % (tag, list(iter(self)))
+    def __eq__(self, x):
+        if x is self: return True
+        if not isinstance(x, PMapView): return False
+        # For whatever reason, dict_values always seem to return False for ==
+        # (probably it's not implemented), so we mimic that.
+        if self._values != False or x._values != False: return False
+        return self._map == x._map
 
 class PMap(object):
     """
@@ -89,6 +151,12 @@ class PMap(object):
     def __iter__(self):
         return self.iterkeys()
 
+    # If this method is not defined, then reversed(pmap) will attempt to reverse
+    # the map using len() and getitem, usually resulting in a mysterious
+    # KeyError.
+    def __reversed__(self):
+        raise TypeError("Persistent maps are not reversible")
+
     def __getattr__(self, key):
         try:
             return self[key]
@@ -115,13 +183,14 @@ class PMap(object):
                     yield k, v
 
     def values(self):
-        return pvector(self.itervalues())
+        return PMapView(self, values=True)
 
     def keys(self):
-        return pvector(self.iterkeys())
+        from ._pset import PSet
+        return PSet(self)
 
     def items(self):
-        return pvector(self.iteritems())
+        return PMapView(self, values=False)
 
     def __len__(self):
         return self._size

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -54,17 +54,19 @@ def test_remove_non_existing_element_raises_key_error():
 
 
 def test_various_iterations():
+    import pyrsistent as pyr
+    
     assert set(['a', 'b']) == set(m(a=1, b=2))
     assert ['a', 'b'] == sorted(m(a=1, b=2).keys())
-    assert isinstance(m().keys(), PVector)
+    assert isinstance(m().keys(), pyr.PSet)
 
     assert set([1, 2]) == set(m(a=1, b=2).itervalues())
     assert [1, 2] == sorted(m(a=1, b=2).values())
-    assert isinstance(m().values(), PVector)
+    assert isinstance(m().values(), pyr._pmap.PMapView)
 
     assert set([('a', 1), ('b', 2)]) == set(m(a=1, b=2).iteritems())
     assert set([('a', 1), ('b', 2)]) == set(m(a=1, b=2).items())
-    assert isinstance(m().items(), PVector)
+    assert isinstance(m().items(), pyr._pmap.PMapView)
 
 
 def test_initialization_with_two_elements():

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -58,26 +58,23 @@ def test_various_iterations():
     
     assert set(['a', 'b']) == set(m(a=1, b=2))
     assert ['a', 'b'] == sorted(m(a=1, b=2).keys())
-    assert isinstance(m().keys(), pyr.PSet)
 
     assert set([1, 2]) == set(m(a=1, b=2).itervalues())
     assert [1, 2] == sorted(m(a=1, b=2).values())
-    assert isinstance(m().values(), pyr._pmap.PMapView)
 
     assert set([('a', 1), ('b', 2)]) == set(m(a=1, b=2).iteritems())
     assert set([('a', 1), ('b', 2)]) == set(m(a=1, b=2).items())
-    assert isinstance(m().items(), pyr._pmap.PMapView)
 
     pm = pmap({k:k for k in range(100)})
     assert len(pm) == len(pm.keys())
     assert len(pm) == len(pm.values())
     assert len(pm) == len(pm.items())
     ks = pm.keys()
-    vs = pm.values()
-    us = pm.items()
     assert all(k in pm for k in ks)
-    assert all(pm[k] == v for (k,v) in us)
     assert all(k in ks for k in ks)
+    us = pm.items()
+    assert all(pm[k] == v for (k,v) in us)
+    vs = pm.values()
     assert all(v in vs for v in vs)
 
 def test_initialization_with_two_elements():

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -68,6 +68,17 @@ def test_various_iterations():
     assert set([('a', 1), ('b', 2)]) == set(m(a=1, b=2).items())
     assert isinstance(m().items(), pyr._pmap.PMapView)
 
+    pm = pmap({k:k for k in range(100)})
+    assert len(pm) == len(pm.keys())
+    assert len(pm) == len(pm.values())
+    assert len(pm) == len(pm.items())
+    ks = pm.keys()
+    vs = pm.values()
+    us = pm.items()
+    assert all(k in pm for k in ks)
+    assert all(pm[k] == v for (k,v) in us)
+    assert all(k in ks for k in ks)
+    assert all(v in vs for v in vs)
 
 def test_initialization_with_two_elements():
     map = pmap({'a': 2, 'b': 3})


### PR DESCRIPTION
This pull request fixes issue #159 and greatly speeds up iteration of `PMap` in Python3—in fact it greatly speeds up creation of the iterator object alone when calling `PMap.keys`, `PMap.values`, and `PMap.items`.

Most of the info is in the commit messages, but I've repeated the relevant bits below (with some minor edits) for convenience!

Happy to iterate on this if there are issues I've missed.

---

Adds a new class `PMapView` to the `pyrsistent._pmap` namespace. This class is intended to be private and essentially mimics the built-in `dict_values` and `dict_items` pseudo-types. Under the hood they just keep a reference to the `PMap` object and use the `iteritems` and `itervalues` methods; this means that creating a view can be run in constant time instead of the current `O(n)` time.

The `keys` method of `PMap` does not use the `PMapView` class because `PSet` is aleady a `PMapView`-type class for `PMap` keys. I couldn't think of a reason not to just use `PSet`: it's the logical type for a set of keys of a persistent map,
and it can just be passed a `PMap` to create such a set in constant time.

The tests were also updated to reflect the reality that `keys` now returns a `PSet` instead of a `PVector` and that `values` and `items` return `PMapView`s.

As a benchmark, the following code:

```python
from timeit import timeit

def make_setup(mapsize):
    return ('from pyrsistent import pmap, pvector; '
            'm = pmap({k:k for k in range(%d)})' % (mapsize,))

tests = [('len(m.keys())',   'len(pvector(m.iterkeys()))'),
         ('len(m.values())', 'len(pvector(m.itervalues()))'),
         ('len(m.items())',  'len(pvector(m.iteritems()))')]

for mapsize in [10, 100, 1000]:
    print("Map size:", str(mapsize))
    setupstr = make_setup(mapsize)
    for test_pair in tests:
        print('=' * 60)
        print('%-40s' % test_pair[0], '%6f us' % timeit(test_pair[0], setup=setupstr))
        print('%-40s' % test_pair[1], '%6f us' % timeit(test_pair[1], setup=setupstr))
        print('-' * 60)
    print('')
```

produces the following output on my desktop:

```
Map size: 10
============================================================
len(m.keys())                            1.330579 us
len(pvector(m.iterkeys()))               1.562125 us
------------------------------------------------------------
============================================================
len(m.values())                          0.653008 us
len(pvector(m.itervalues()))             1.584405 us
------------------------------------------------------------
============================================================
len(m.items())                           0.653144 us
len(pvector(m.iteritems()))              1.159099 us
------------------------------------------------------------

Map size: 100
============================================================
len(m.keys())                            1.350190 us
len(pvector(m.iterkeys()))               11.702080 us
------------------------------------------------------------
============================================================
len(m.values())                          0.650723 us
len(pvector(m.itervalues()))             11.739465 us
------------------------------------------------------------
============================================================
len(m.items())                           0.653189 us
len(pvector(m.iteritems()))              8.951215 us
------------------------------------------------------------

Map size: 1000
============================================================
len(m.keys())                            1.379429 us
len(pvector(m.iterkeys()))               114.202673 us
------------------------------------------------------------
============================================================
len(m.values())                          0.679722 us
len(pvector(m.itervalues()))             113.874931 us
------------------------------------------------------------
============================================================
len(m.items())                           0.680877 us
len(pvector(m.iteritems()))              87.645472 us
------------------------------------------------------------
```

These tests were run with the version in this pull request, so the first test is always the new approach and the second test is always the previous approach.