### PR TITLE
Add changelog URL to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ setup(
     author='Tobias Gustafsson',
     author_email='tobias.l.gustafsson@gmail.com',
     url='https://github.com/tobgu/pyrsistent/',
+    project_urls={
+        'Changelog': 'https://pyrsistent.readthedocs.io/en/latest/changes.html',
+    },
     license='MIT',
     license_files=['LICENSE.mit'],
     py_modules=['_pyrsistent_version'],


### PR DESCRIPTION
When Renovate bot creates an automated pull request to update packages, it can automatically include the link to changelog so it's easier to find out what changed.

The URL key has to be one of: 'changelog', 'change log', 'changes', 'release notes', 'news', "what's new" (case insensitive)

Code: https://github.com/renovatebot/renovate/blob/c3a87b687ed44a1a100e0e4f91b81e22b7c32482/lib/modules/datasource/pypi/index.ts#L130-L140