### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python: [37, 38, 39, 310]
+        python: [37, 38, 39, 310, 311]
         bitness: [32, 64]
         include:
           # Run 32 and 64 bit version in parallel for Linux and Windows
@@ -61,6 +61,9 @@ jobs:
           - os: macos-latest
             python: 310
             platform_id: macosx_universal2
+          - os: macos-latest
+            python: 311
+            platform_id: macosx_universal2
         exclude:
           - os: macos-latest
             bitness: 32
@@ -75,7 +78,7 @@ jobs:
       CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -84,9 +87,9 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.9.0
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -96,7 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.9'
@@ -114,7 +117,7 @@ jobs:
         env:
           PYRSISTENT_SKIP_EXTENSION: yes
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*
 
@@ -128,14 +131,14 @@ jobs:
     # if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
       - name: Publish test release
         if: github.event.inputs.target == 'test'
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -144,7 +147,7 @@ jobs:
 
       - name: Publish release
         if: github.event.inputs.target != 'test'
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
          user: __token__
          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.9", "3.10"]
+        python-version: ["3.7", "3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/pyrsistent/_immutable.py
+++ b/pyrsistent/_immutable.py
@@ -60,14 +60,9 @@ def immutable(members='', name='Immutable', verbose=False):
 
         return ''
 
-    verbose_string = ""
-    if sys.version_info < (3, 7):
-        # Verbose is no longer supported in Python 3.7
-        verbose_string = ", verbose={verbose}".format(verbose=verbose)
-
     quoted_members = ', '.join("'%s'" % m for m in members)
     template = """
-class {class_name}(namedtuple('ImmutableBase', [{quoted_members}]{verbose_string})):
+class {class_name}(namedtuple('ImmutableBase', [{quoted_members}])):
     __slots__ = tuple()
 
     def __repr__(self):
@@ -87,7 +82,6 @@ class {class_name}(namedtuple('ImmutableBase', [{quoted_members}]{verbose_string
 """.format(quoted_members=quoted_members,
                member_set="set([%s])" % quoted_members if quoted_members else 'set()',
                frozen_member_test=frozen_member_test(),
-               verbose_string=verbose_string,
                class_name=name)
 
     if verbose:

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     test_suite='tests',

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,14 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37,py38,py39,py310,pypy3,memorytest38,doctest38,coverage-py38
+envlist = py{37,38,39,310,311,py3},memorytest38,doctest38,coverage-py38
 
 [gh-actions]
 python =
     3.7: py37
     3.9: py39
     3.10: py310
+    3.11: py311
 
 # Skipping 3.8 under GH actions for now. Need to fix coverage first.
 


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

Also remove some redundant Python < 3.7 code and bump GitHub Actions.