### PR TITLE
Add pyrsistent.typing to the API documentation.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,4 +1,11 @@
 API documentation
 =================
+
 .. automodule:: pyrsistent
+   :members:
+
+pyrsistent.typing
+-----------------
+
+.. automodule:: pyrsistent.typing
    :members:


### PR DESCRIPTION
These were previously not linked anywhere indexable in pyrsistent's documentation, which makes it harder for downstream projects which use them because the intersphinx links (from downstream project to pyrsistent's docs) will fail whenever these are used.