### PR TITLE
Attempt to make type hints covariant

### DIFF
--- a/pyrsistent/typing.py
+++ b/pyrsistent/typing.py
@@ -36,36 +36,38 @@ try:
     ]
 
     T = TypeVar('T')
+    T_co = TypeVar('T_co', covariant=True)
     KT = TypeVar('KT')
     VT = TypeVar('VT')
+    VT_co = TypeVar('VT_co', covariant=True)
 
-    class CheckedPMap(Mapping[KT, VT], Hashable):
+    class CheckedPMap(Mapping[KT, VT_co], Hashable):
         pass
 
     # PSet.add and PSet.discard have different type signatures than that of Set.
-    class CheckedPSet(Generic[T], Hashable):
+    class CheckedPSet(Generic[T_co], Hashable):
         pass
 
-    class CheckedPVector(Sequence[T], Hashable):
+    class CheckedPVector(Sequence[T_co], Hashable):
         pass
 
-    class PBag(Container[T], Iterable[T], Sized, Hashable):
+    class PBag(Container[T_co], Iterable[T_co], Sized, Hashable):
         pass
 
-    class PDeque(Sequence[T], Hashable):
+    class PDeque(Sequence[T_co], Hashable):
         pass
 
-    class PList(Sequence[T], Hashable):
+    class PList(Sequence[T_co], Hashable):
         pass
 
-    class PMap(Mapping[KT, VT], Hashable):
+    class PMap(Mapping[KT, VT_co], Hashable):
         pass
 
     # PSet.add and PSet.discard have different type signatures than that of Set.
-    class PSet(Generic[T], Hashable):
+    class PSet(Generic[T_co], Hashable):
         pass
 
-    class PVector(Sequence[T], Hashable):
+    class PVector(Sequence[T_co], Hashable):
         pass
 
     class PVectorEvolver(Generic[T]):


### PR DESCRIPTION
Fixes #274

This is an attempt to fix the variance of Pyrsistent's generic type hints.  I don't really know what I'm doing, but following @kulych's suggestion in #274 and @bryanforbes's approach in [immutables.Map](https://github.com/MagicStack/immutables/blob/v0.19/immutables/_map.pyi#L24), I've added new covariant type variables and used them in immutable container hints.  This approach seems to fix mypy covariance issues in my own code that uses PVector.

## Questions for reviewer:
- [ ] are there any tests I should run?
- [ ] should I do anything about other mypy errors in Pyrsistent?

<details>

```
% mypy --install-types .
docs/source/conf.py:76: error: Need type annotation for "exclude_patterns" (hint: "exclude_patterns: List[<type>] = ...")  [var-annotated]
docs/source/conf.py:110: error: Cannot find implementation or library stub for module named "sphinx_rtd_theme"  [import]
docs/source/conf.py:199: error: Need type annotation for "latex_elements" (hint: "latex_elements: Dict[<type>, <type>] = ...")  [var-annotated]
benchmarks/pmap.py:1: error: Cannot find implementation or library stub for module named "pyperform"  [import]
benchmarks/pmap.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
setup.py:83: error: Dict entry 0 has incompatible type "str": "type[custom_build_ext]"; expected "str": "type[Command]"  [dict-item]
pyrsistent/_transformations.py:5: error: Incompatible types in assignment (expression has type "None", variable has type "Callable[[Callable[..., Any], DefaultNamedArg(bool, 'follow_wrapped'), DefaultNamedArg(Mapping[str, Any] | None, 'globals'), DefaultNamedArg(Mapping[str, Any] | None, 'locals'), DefaultNamedArg(bool, 'eval_str')], Signature]")  [assignment]
pyrsistent/_pvector.py:678: error: Only concrete class can be given where "type[PVector]" is expected  [type-abstract]
pyrsistent/_pvector.py:679: error: Only concrete class can be given where "type[PVector]" is expected  [type-abstract]
pyrsistent/_pvector.py:697: error: Cannot find implementation or library stub for module named "pvectorc"  [import]
pyrsistent/_pvector.py:697: error: Name "pvector" already defined on line 695  [no-redef]
benchmarks/pvector.py:1: error: Cannot find implementation or library stub for module named "pyperform"  [import]
benchmarks/pvector.py:83: error: Name "append_native_pvector" already defined on line 65  [no-redef]
benchmarks/pvector.py:89: error: Name "append_python_pvector" already defined on line 71  [no-redef]
benchmarks/pvector.py:95: error: Name "reference_append_list" already defined on line 77  [no-redef]
benchmarks/pvector.py:180: error: Name "random_insert_large_native_pvector_evolver" already defined on line 172  [no-redef]
pyrsistent/_field_common.py:176: error: Need type annotation for "_seq_field_types" (hint: "_seq_field_types: Dict[<type>, <type>] = ...")  [var-annotated]
pyrsistent/_field_common.py:279: error: Need type annotation for "_pmap_field_types" (hint: "_pmap_field_types: Dict[<type>, <type>] = ...")  [var-annotated]
tests/record_test.py:13: error: Need type annotation for "y"  [var-annotated]
tests/record_test.py:25: error: Incompatible types in assignment (expression has type "PSet[str]", base class "PRecord" defined the type as overloaded function)  [assignment]
tests/immutable_object_test.py:4: error: Unsupported dynamic base class "immutable"  [misc]
tests/immutable_object_test.py:8: error: Unsupported dynamic base class "immutable"  [misc]
tests/immutable_object_test.py:12: error: Unsupported dynamic base class "immutable"  [misc]
tests/immutable_object_test.py:16: error: Unsupported dynamic base class "immutable"  [misc]
tests/hypothesis_vector_test.py:91: error: Need type annotation for "sequences"  [var-annotated]
tests/hypothesis_vector_test.py:208: error: Need type annotation for "original_list"  [var-annotated]
tests/hypothesis_vector_test.py:209: error: Need type annotation for "original_pvector"  [var-annotated]
tests/hypothesis_vector_test.py:210: error: Need type annotation for "current_list"  [var-annotated]
tests/hypothesis_vector_test.py:211: error: Need type annotation for "current_evolver"  [var-annotated]
tests/hypothesis_vector_test.py:221: error: Need type annotation for "sequences"  [var-annotated]
tests/class_test.py:23: error: Incompatible types in assignment (expression has type "PSet[str]", base class "PClass" defined the type as "Callable[[T_PClass, VarArg(Any), KwArg(Any)], T_PClass]")  [assignment]
tests/checked_vector_test.py:101: error: Incompatible types in assignment (expression has type "tuple[type[int], type[None]]", base class "CheckedPVector" defined the type as "type[Any]")  [assignment]
tests/checked_vector_test.py:108: error: Incompatible types in assignment (expression has type "tuple[type[Naturals], type[None]]", base class "CheckedPVector" defined the type as "type[Any]")  [assignment]
tests/checked_vector_test.py:187: error: Incompatible types in assignment (expression has type "str", base class "CheckedPVector" defined the type as "type[Any]")  [assignment]
tests/checked_map_test.py:130: error: Incompatible types in assignment (expression has type "str", base class "CheckedPMap" defined the type as "type[Any]")  [assignment]
tests/checked_map_test.py:131: error: Incompatible types in assignment (expression has type "str", base class "CheckedPMap" defined the type as "type[Any]")  [assignment]
tests/memory_profiling.py:7: error: Cannot find implementation or library stub for module named "memory_profiler"  [import]
tests/memory_profiling.py:12: error: Cannot find implementation or library stub for module named "pvectorc"  [import]
Found 37 errors in 14 files (checked 41 source files)
```

</details>

## Tested in:
- Python 3.11.3
- mypy 1.4.1