### PR TITLE
Fix: Enable freezing collections.defaultdict objects

### DIFF
--- a/pyrsistent/_helpers.py
+++ b/pyrsistent/_helpers.py
@@ -31,7 +31,7 @@ def freeze(o, strict=True):
     (1, pvector([]))
     """
     typ = type(o)
-    if typ is dict or (strict and isinstance(o, PMap)):
+    if isinstance(o, dict) or (strict and isinstance(o, PMap)):
         return pmap({k: freeze(v, strict) for k, v in o.items()})
     if typ is list or (strict and isinstance(o, PVector)):
         curried_freeze = lambda x: freeze(x, strict)

--- a/pyrsistent/_helpers.py
+++ b/pyrsistent/_helpers.py
@@ -1,3 +1,4 @@
+import collections
 from functools import wraps
 from pyrsistent._pmap import PMap, pmap
 from pyrsistent._pset import PSet, pset
@@ -10,6 +11,7 @@ def freeze(o, strict=True):
 
     - list is converted to pvector, recursively
     - dict is converted to pmap, recursively on values (but not keys)
+    - defaultdict is converted to pmap, recursively on values (but not keys)
     - set is converted to pset, but not recursively
     - tuple is converted to tuple, recursively.
 
@@ -31,7 +33,9 @@ def freeze(o, strict=True):
     (1, pvector([]))
     """
     typ = type(o)
-    if isinstance(o, dict) or (strict and isinstance(o, PMap)):
+    if typ is dict or (strict and isinstance(o, PMap)):
+        return pmap({k: freeze(v, strict) for k, v in o.items()})
+    if typ is collections.defaultdict or (strict and isinstance(o, PMap)):
         return pmap({k: freeze(v, strict) for k, v in o.items()})
     if typ is list or (strict and isinstance(o, PVector)):
         curried_freeze = lambda x: freeze(x, strict)

--- a/tests/freeze_test.py
+++ b/tests/freeze_test.py
@@ -1,5 +1,5 @@
 """Tests for freeze and thaw."""
-
+import collections
 from pyrsistent import v, m, s, freeze, thaw, PRecord, field, mutant
 
 
@@ -17,6 +17,13 @@ def test_freeze_dict():
     assert result == m(a='b')
     assert type(freeze({'a': 'b'})) is type(m())
 
+def test_freeze_defaultdict():
+    test_dict = collections.defaultdict(dict)
+    test_dict['a'] = 'b'
+    result = freeze(test_dict)
+    assert result == m(a='b')
+    assert type(freeze({'a': 'b'})) is type(m())
+
 def test_freeze_set():
     result = freeze(set([1, 2, 3]))
     assert result == s(1, 2, 3)
@@ -24,6 +31,13 @@ def test_freeze_set():
 
 def test_freeze_recurse_in_dictionary_values():
     result = freeze({'a': [1]})
+    assert result == m(a=v(1))
+    assert type(result['a']) is type(v())
+
+def test_freeze_recurse_in_defaultdict_values():
+    test_dict = collections.defaultdict(dict)
+    test_dict['a'] = [1]
+    result = freeze(test_dict)
     assert result == m(a=v(1))
     assert type(result['a']) is type(v())
 


### PR DESCRIPTION
Fixes #280 

Solution:
Changing the condition from ```typ is dict``` to ```isinstance(o, dict)``` enables the ```freeze``` function to convert objects of collections.defaultdict type to ```Pmap```.