### PR TITLE
Replace _PyList_Extend with PyList_SetSlice

### DIFF
--- a/pvectorcmodule.c
+++ b/pvectorcmodule.c
@@ -1313,12 +1313,10 @@ static PyObject *PVectorEvolver_append(PVectorEvolver *self, PyObject *args) {
 }
 
 static PyObject *PVectorEvolver_extend(PVectorEvolver *self, PyObject *args) {
-  PyObject *retVal = _PyList_Extend((PyListObject *)self->appendList, args);
-  if (retVal == NULL) {
+  if (PyList_SetSlice(self->appendList, PY_SSIZE_T_MAX, PY_SSIZE_T_MAX, args) < 0) {
     return NULL;
   }
 
-  Py_DECREF(retVal);
   Py_INCREF(self);
   return (PyObject*)self;
 }


### PR DESCRIPTION
This private function is no longer exported in Python 3.13.

It is possible that a `PyList_Extend()` function-like macro may be added before Python 3.13 final, but using `PyList_SetSlice()` directly will still work.

See also:

https://github.com/python/cpython/pull/108451

https://github.com/python/cpython/issues/111138

After this PR, `pyrsistent` builds and the tests pass on Python 3.13.0a1.