### PR TITLE
Refactor build workflow matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,53 +15,36 @@ on:
 
 jobs:
   build_wheels:
-    name: Build ${{ matrix.python }} wheels on ${{ matrix.os }}-${{ matrix.platform_id }}
-    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.python }} wheels on ${{ matrix.platform.os }}-${{ matrix.platform.id }}
+    runs-on: ${{ matrix.platform.os }}
     strategy:
       # Ensure the wheels build even if one fails.
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
         python: [38, 39, 310, 311, 312]
-        platform_id:
-          - win_amd64
-          - win32
-          - manylinux_x86_64
-          - manylinux_i686
-          - manylinux_aarch64
-          - macosx_universal2
-        exclude:
-          # Skip Linux and Mac builds on Windows
-          - os: windows-latest
-            platform_id: manylinux_aarch64
-          - os: windows-latest
-            platform_id: manylinux_i686
-          - os: windows-latest
-            platform_id: manylinux_x86_64
-          - os: windows-latest
-            platform_id: macosx_universal2
-          # Skip Mac and Windows builds on Linux
-          - os: ubuntu-latest
-            platform_id: macosx_universal2
-          - os: ubuntu-latest
-            platform_id: win_amd64
-          - os: ubuntu-latest
-            platform_id: win32
-          # Skip Linux and Windows builds on Mac
-          - os: macos-latest
-            platform_id: win_amd64
-          - os: macos-latest
-            platform_id: win32
-          - os: macos-latest
-            platform_id: manylinux_x86_64
-          - os: macos-latest
-            platform_id: manylinux_i686
-          - os: macos-latest
-            platform_id: manylinux_aarch64
+        platform:
+          - id: win_amd64
+            os: windows-latest
+            qemu: false
+          - id: win32
+            os: windows-latest
+            qemu: false
+          - id: manylinux_x86_64
+            os: ubuntu-latest
+            qemu: false
+          - id: manylinux_i686
+            os: ubuntu-latest
+            qemu: true
+          - id: manylinux_aarch64
+            os: ubuntu-latest
+            qemu: true
+          - id: macosx_universal2
+            os: macos-latest
+            qemu: false
     env:
       CIBW_ARCHS_LINUX: auto aarch64
       CIBW_ARCHS_MACOS: universal2
-      CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
+      CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform.id }}
       CIBW_TEST_REQUIRES: pytest==6.* hypothesis==6.*
       CIBW_TEST_COMMAND: "bash {project}/tools/test_wheels.sh {project}"
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -72,8 +55,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up QEMU
-        if: |
-          runner.os == 'Linux' && (matrix.platform_id == 'manylinux_aarch64' || matrix.platform_id == 'manylinux_i686')
+        if: matrix.platform.qemu
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all


### PR DESCRIPTION
The current matrix of os + platform_id with a bunch of excludes is replaced with a list of objects.

A similar set of changes was tested in my pyrsistent-extras library: https://github.com/mingmingrr/pyrsistent-extras/actions/runs/8838883205