### PR TITLE
Update the tox config so the test suite passes when run locally

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{38,39,310,311,312,py3},memorytest38,doctest38,coverage-py38
+envlist =
+    py{3.12, 3.11, 3.10, 3.9, 3.8}
+    pypy{3.10}
+    memorytest38
+    doctest38
+    coverage-py38
 
 [gh-actions]
 python =
@@ -16,15 +21,19 @@ python =
 # Skipping 3.8 under GH actions for now. Need to fix coverage first.
 
 [testenv]
-commands = python {toxinidir}/setup.py test
+commands = pytest
 deps =
-    setuptools
+    pytest
+    hypothesis
 
 # Specifying the following tests like this is very non-DRY but I have no better solution right now.
 [testenv:coverage-py38]
 # Skip using C-extension to get coverage metrics on Python code.
 basepython = python3.8
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+passenv =
+    TRAVIS
+    TRAVIS_BRANCH
+    TRAVIS_JOB_ID
 setenv =
     PYRSISTENT_NO_C_EXTENSION = 1
 deps =
@@ -36,7 +45,9 @@ deps =
 changedir = tests
 commands =
     pytest --cov=pyrsistent
-    coveralls
+    # Ignore the coveralls return code.
+    # This allows the tox environment to be run locally without errors.
+    - coveralls
 
 [testenv:memorytest38]
 basepython = python3.8


### PR DESCRIPTION
This PR makes the following changes to `tox.ini`:

* The `envlist` is converted to a multiline list.

  _This makes future PRs (say, to test against Python 3.13 and PyPy 3.11, or to test building the docs, or to test mypy) easier to read and less likely to have merge conflicts._
* `python {toxinidir}/setup.py test` is removed in favor of simply `pytest`.

  _This is necessary because it's no longer possible to run `python setup.py test`. I'm pasting a sample of the errors below._
* A `passenv` is converted to a multiline list.

  _Tox no longer recognizes space-separated environment variable names._

* The `coveralls` command's return code is ignored when determining whether an error has occurred.

  _When run locally, coveralls fails because it's not running in Travis CI, which causes the coverage tests to be marked as a failure._


----

Below is the error that occurs when running `python setup.py test`.

```
$ python setup.py test
No `name` configuration, performing automatic discovery
/home/kurt/.cache/virtualenvs/4500f02a6a9f4c0015d56455fb32e71b-pr-pyrsistent/lib/python3.13/site-packages/setuptools/__init__.py:94: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  dist.fetch_build_eggs(dist.setup_requires)
/home/kurt/.cache/virtualenvs/4500f02a6a9f4c0015d56455fb32e71b-pr-pyrsistent/lib/python3.13/site-packages/setuptools/_distutils/dist.py:270: UserWarning: Unknown distribution option: 'test_suite'
  warnings.warn(msg)
/home/kurt/.cache/virtualenvs/4500f02a6a9f4c0015d56455fb32e71b-pr-pyrsistent/lib/python3.13/site-packages/setuptools/_distutils/dist.py:270: UserWarning: Unknown distribution option: 'tests_require'
  warnings.warn(msg)
/home/kurt/dev/pr-pyrsistent/.eggs/pytest_runner-6.0.1-py3.13.egg/ptr/__init__.py:81: SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
!!

        ********************************************************************************
        Please remove any references to `setuptools.command.test` in all supported versions of the affected package.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************

!!
  class PyTest(orig.test):
running pytest
Traceback (most recent call last):
  File "/home/kurt/dev/pr-pyrsistent/setup.py", line 53, in <module>
    setup(
    ~~~~~^
        name='pyrsistent',
        ^^^^^^^^^^^^^^^^^^
    ...<31 lines>...
        python_requires='>=3.8',
        ^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/kurt/.cache/virtualenvs/4500f02a6a9f4c0015d56455fb32e71b-pr-pyrsistent/lib/python3.13/site-packages/setuptools/__init__.py", line 117, in setup
    return distutils.core.setup(**attrs)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/kurt/.cache/virtualenvs/4500f02a6a9f4c0015d56455fb32e71b-pr-pyrsistent/lib/python3.13/site-packages/setuptools/_distutils/core.py", line 186, in setup
    return run_commands(dist)
  File "/home/kurt/.cache/virtualenvs/4500f02a6a9f4c0015d56455fb32e71b-pr-pyrsistent/lib/python3.13/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
    dist.run_commands()
    ~~~~~~~~~~~~~~~~~^^
  File "/home/kurt/.cache/virtualenvs/4500f02a6a9f4c0015d56455fb32e71b-pr-pyrsistent/lib/python3.13/site-packages/setuptools/_distutils/dist.py", line 983, in run_commands
    self.run_command(cmd)
    ~~~~~~~~~~~~~~~~^^^^^
  File "/home/kurt/.cache/virtualenvs/4500f02a6a9f4c0015d56455fb32e71b-pr-pyrsistent/lib/python3.13/site-packages/setuptools/dist.py", line 999, in run_command
    super().run_command(command)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/kurt/.cache/virtualenvs/4500f02a6a9f4c0015d56455fb32e71b-pr-pyrsistent/lib/python3.13/site-packages/setuptools/_distutils/dist.py", line 1002, in run_command
    cmd_obj.run()
    ~~~~~~~~~~~^^
  File "/home/kurt/dev/pr-pyrsistent/.eggs/pytest_runner-6.0.1-py3.13.egg/ptr/__init__.py", line 195, in run
    setattr(dist, attr, getattr(self.distribution, attr))
                        ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Distribution' object has no attribute 'tests_require'. Did you mean: 'extras_require'?
```