### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,19 +69,19 @@ jobs:
       CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         if: |
           runner.os == 'Linux' && (matrix.platform_id == 'manylinux_aarch64' || matrix.platform_id == 'manylinux_i686')
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.22.0
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -89,9 +89,9 @@ jobs:
     name: Build source distribution and pure python wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.10'
@@ -109,7 +109,7 @@ jobs:
         env:
           PYRSISTENT_SKIP_EXTENSION: yes
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*
 
@@ -123,14 +123,14 @@ jobs:
     # if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
 
       - name: Publish test release
         if: github.event.inputs.target == 'test'
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
 
       - name: Publish release
         if: github.event.inputs.target != 'test'
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
          user: __token__
          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
This PR updates the GitHub action versions to the latest versions available.

However, note that it is extremely likely that artifact uploads and downloads will need to be fixed -- it looks like multiple artifacts may have been uploaded using the same name, and [this is no longer supported](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes).