### PR TITLE
Remove the deprecated/unmaintained pytest-runner dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ extensions = []
 if platform.python_implementation() == 'CPython' and os.getenv("PYRSISTENT_SKIP_EXTENSION") is None:
     extensions = [Extension('pvectorc', sources=['pvectorcmodule.c'])]
 
-needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
-
 
 class custom_build_ext(build_ext):
     """Allow C extension building to fail."""
@@ -75,10 +72,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
-    test_suite='tests',
-    tests_require=['pytest<7', 'hypothesis<7'],
     scripts=[],
-    setup_requires=pytest_runner,
     ext_modules=extensions,
     cmdclass={'build_ext': custom_build_ext},
     packages=['pyrsistent'],

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ python =
 # Skipping 3.8 under GH actions for now. Need to fix coverage first.
 
 [testenv]
-commands = python {toxinidir}/setup.py test
+commands = pytest
 deps =
-    setuptools
+    pytest
+    hypothesis
 
 # Specifying the following tests like this is very non-DRY but I have no better solution right now.
 [testenv:coverage-py38]


### PR DESCRIPTION
The `python setup.py test` command [is deprecated and will be removed in the future](https://setuptools.pypa.io/en/latest/deprecated/commands.html#test-build-package-and-run-a-unittest-suite), and [pytest-runner is no longer maintained](https://github.com/pytest-dev/pytest-runner/?tab=readme-ov-file#deprecation-notice).

This PR removes pytest-runner references, as well as references to `python setup.py test`.
