### PR TITLE
Simplify the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,43 +21,38 @@ jobs:
       # Ensure the wheels build even if one fails.
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        python: [38, 39, 310, 311, 312]
+        python:
+          - "38"
+          - "39"
+          - "310"
+          - "311"
+          - "312"
         platform_id:
-          - win_amd64
-          - win32
-          - manylinux_x86_64
-          - manylinux_i686
-          - manylinux_aarch64
           - macosx_universal2
-        exclude:
-          # Skip Linux and Mac builds on Windows
-          - os: windows-latest
-            platform_id: manylinux_aarch64
-          - os: windows-latest
-            platform_id: manylinux_i686
-          - os: windows-latest
-            platform_id: manylinux_x86_64
-          - os: windows-latest
-            platform_id: macosx_universal2
-          # Skip Mac and Windows builds on Linux
-          - os: ubuntu-latest
-            platform_id: macosx_universal2
-          - os: ubuntu-latest
-            platform_id: win_amd64
-          - os: ubuntu-latest
-            platform_id: win32
-          # Skip Linux and Windows builds on Mac
-          - os: macos-latest
-            platform_id: win_amd64
-          - os: macos-latest
-            platform_id: win32
-          - os: macos-latest
-            platform_id: manylinux_x86_64
-          - os: macos-latest
-            platform_id: manylinux_i686
-          - os: macos-latest
-            platform_id: manylinux_aarch64
+          - manylinux_aarch64
+          - manylinux_i686
+          - manylinux_x86_64
+          - win32
+          - win_amd64
+
+        include:
+          # For each matching 'platform_id' above, add an 'os'.
+          # Linux
+          - platform_id: manylinux_aarch64
+            os: ubuntu-latest
+          - platform_id: manylinux_i686
+            os: ubuntu-latest
+          - platform_id: manylinux_x86_64
+            os: ubuntu-latest
+          # macOS
+          - platform_id: macosx_universal2
+            os: macos-latest
+          # Windows
+          - platform_id: win32
+            os: windows-latest
+          - platform_id: win_amd64
+            os: windows-latest
+
     env:
       CIBW_ARCHS_LINUX: auto aarch64
       CIBW_ARCHS_MACOS: universal2
@@ -72,8 +67,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up QEMU
-        if: |
-          runner.os == 'Linux' && (matrix.platform_id == 'manylinux_aarch64' || matrix.platform_id == 'manylinux_i686')
+        if: matrix.platform_id == 'manylinux_aarch64' || matrix.platform_id == 'manylinux_i686'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all


### PR DESCRIPTION
@tobgu The current build matrix relies on excluding a significant portion of the cross product of all `platform_id` and `os` combinations.

This PR converts the `exclude` behavior to `include` behavior. This is accomplished by using GitHub's value-matching behavior. For example:

1. The matrix will generate multiple 'win32' values, each matched with a different 'python' value (win32-39, win32-310, etc).
2. The `include` value that has a 'win32' `platform_id` value will match each existing 'win32' value and add the 'windows-latest' `os` value to each (win32-39-windows-latest, win32-310-windows-latest, etc).

This makes the build matrix much clearer and reduces the build matrix maintenance burden.