### PR TITLE
Test new CPython/PyPy versions; build for Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           - "310"
           - "311"
           - "312"
+          - "313"
         platform_id:
           - macosx_universal2
           - manylinux_aarch64

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,12 +9,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
+        allow-prereleases: true
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     scripts=[],

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@
 
 [tox]
 envlist =
-    py{3.12, 3.11, 3.10, 3.9, 3.8}
-    pypy{3.10}
+    py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9, 3.8}
+    pypy{3.11, 3.10}
     memorytest38
     doctest38
     coverage-py38
@@ -17,6 +17,8 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 # Skipping 3.8 under GH actions for now. Need to fix coverage first.
 


### PR DESCRIPTION
This adds local testing for:

* CPython 3.13
* CPython 3.14
* PyPy 3.11

and CI testing for:

* CPython 3.13
* CPython 3.14

and adds builds for:

* CPython 3.13

> [!NOTE]
>
> CPython 3.14 is currently only at alpha 5, so it is not yet targeted for wheel builds.
> In addition, PyPy is not yet tested in CI, so a larger change would be needed to add this.