### PR TITLE
Run `pyupgrade --py38-plus` against the codebase

### DIFF
--- a/benchmarks/pmap.py
+++ b/benchmarks/pmap.py
@@ -4,7 +4,7 @@ from pyrsistent import pmap #!
 
 class Benchmarked(BenchmarkedFunction):
     def __init__(self, scale=1, *args, **kwargs):
-        super(Benchmarked, self).__init__(*args, timeit_number=scale*1000, **kwargs)
+        super().__init__(*args, timeit_number=scale*1000, **kwargs)
 
 ################# Create ###################
 
@@ -20,11 +20,11 @@ def reference_create_empty_dict():
 
 
 def _small_dict():
-    small_dict = dict((i, i) for i in range(10))
+    small_dict = {i: i for i in range(10)}
 
 
 def _large_dict():
-    large_dict = dict((i, i) for i in range(2000))
+    large_dict = {i: i for i in range(2000)}
 
 
 @Benchmarked(setup=_small_dict)
@@ -55,7 +55,7 @@ def reference_create_large_dict():
 
 
 def _small_pmap():
-    small_pmap = pmap(dict((i, i) for i in range(10)))
+    small_pmap = pmap({i: i for i in range(10)})
 
 
 @Benchmarked(setup=_small_pmap)
@@ -71,7 +71,7 @@ def reference_random_replace_small_dict():
 
 
 def _large_pmap():
-    large_pmap = pmap(dict((i, i) for i in range(2000)))
+    large_pmap = pmap({i: i for i in range(2000)})
 
 
 @Benchmarked(setup=_large_pmap)
@@ -169,43 +169,43 @@ def reference_iteration_large_dict():
 # #################### Comparison ########################
 
 def _different_pmaps_same_size():
-    pmap1 = pmap(dict((i, i) for i in range(2000)))
-    pmap2 = pmap(dict((i, i + 1) for i in range(2000)))
+    pmap1 = pmap({i: i for i in range(2000)})
+    pmap2 = pmap({i: i + 1 for i in range(2000)})
 
 
 def _different_pmaps_different_size():
-    pmap1 = pmap(dict((i, i) for i in range(2000)))
-    pmap2 = pmap(dict((i, i + 1) for i in range(1500)))
+    pmap1 = pmap({i: i for i in range(2000)})
+    pmap2 = pmap({i: i + 1 for i in range(1500)})
 
 
 def _equal_pmaps():
-    pmap1 = pmap(dict((i, i) for i in range(2000)))
-    pmap2 = pmap(dict((i, i) for i in range(2000)))
+    pmap1 = pmap({i: i for i in range(2000)})
+    pmap2 = pmap({i: i for i in range(2000)})
 
 
 def _equal_pmap_and_dict():
-    dict1 = dict((i, i) for i in range(2000))
-    pmap1 = pmap(dict((i, i) for i in range(2000)))
+    dict1 = {i: i for i in range(2000)}
+    pmap1 = pmap({i: i for i in range(2000)})
 
 
 def _equal_dicts():
-    dict1 = dict((i, i) for i in range(2000))
-    dict2 = dict((i, i) for i in range(2000))
+    dict1 = {i: i for i in range(2000)}
+    dict2 = {i: i for i in range(2000)}
 
 
 def _different_dicts_same_size():
-    dict1 = dict((i, i) for i in range(2000))
-    dict2 = dict((i, i + 1) for i in range(2000))
+    dict1 = {i: i for i in range(2000)}
+    dict2 = {i: i + 1 for i in range(2000)}
 
 
 def _different_dicts_different_size():
-    dict1 = dict((i, i) for i in range(2000))
-    dict2 = dict((i, i + 1) for i in range(2000))
+    dict1 = {i: i for i in range(2000)}
+    dict2 = {i: i + 1 for i in range(2000)}
 
 
 def _equal_pmaps_different_bucket_size():
-    pmap1 = pmap(dict((i, i) for i in range(2000)), 1999)
-    pmap2 = pmap(dict((i, i) for i in range(2000)), 2000)
+    pmap1 = pmap({i: i for i in range(2000)}, 1999)
+    pmap2 = pmap({i: i for i in range(2000)}, 2000)
 
 
 def _equal_pmaps_same_bucket_size_different_insertion_order():

--- a/benchmarks/pvector.py
+++ b/benchmarks/pvector.py
@@ -4,7 +4,7 @@ from pyrsistent import _pvector, _pvector #!
 
 class Benchmarked(BenchmarkedFunction):
     def __init__(self, scale=1, *args, **kwargs):
-        super(Benchmarked, self).__init__(*args, timeit_number=scale*1000, **kwargs)
+        super().__init__(*args, timeit_number=scale*1000, **kwargs)
 
 ################# Create ###################
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Pyrsistent documentation build configuration file, created by
 # sphinx-quickstart on Sun Nov 10 08:52:58 2013.
@@ -48,8 +47,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Pyrsistent'
-copyright = u'2023, Tobias Gustafsson'
+project = 'Pyrsistent'
+copyright = '2023, Tobias Gustafsson'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -203,8 +202,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Pyrsistent.tex', u'Pyrsistent Documentation',
-   u'Tobias Gustafsson', 'manual'),
+  ('index', 'Pyrsistent.tex', 'Pyrsistent Documentation',
+   'Tobias Gustafsson', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -233,8 +232,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'pyrsistent', u'Pyrsistent Documentation',
-     [u'Tobias Gustafsson'], 1)
+    ('index', 'pyrsistent', 'Pyrsistent Documentation',
+     ['Tobias Gustafsson'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -247,8 +246,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Pyrsistent', u'Pyrsistent Documentation',
-   u'Tobias Gustafsson', 'Pyrsistent', 'One line description of project.',
+  ('index', 'Pyrsistent', 'Pyrsistent Documentation',
+   'Tobias Gustafsson', 'Pyrsistent', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/pyrsistent/__init__.py
+++ b/pyrsistent/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from pyrsistent._pmap import pmap, m, PMap
 
 from pyrsistent._pvector import pvector, v, PVector

--- a/pyrsistent/_field_common.py
+++ b/pyrsistent/_field_common.py
@@ -40,7 +40,7 @@ def serialize(serializer, format, value):
 def check_type(destination_cls, field, name, value):
     if field.type and not any(isinstance(value, get_type(t)) for t in field.type):
         actual_type = type(value)
-        message = "Invalid type for field {0}.{1}, was {2}".format(destination_cls.__name__, name, actual_type.__name__)
+        message = f"Invalid type for field {destination_cls.__name__}.{name}, was {actual_type.__name__}"
         raise PTypeError(destination_cls, name, field.type, actual_type, message)
 
 
@@ -65,7 +65,7 @@ def is_field_ignore_extra_complaint(type_cls, field, ignore_extra):
 
 
 
-class _PField(object):
+class _PField:
     __slots__ = ('type', 'invariant', 'initial', 'mandatory', '_factory', 'serializer')
 
     def __init__(self, type, invariant, initial, mandatory, factory, serializer):
@@ -132,12 +132,12 @@ def field(type=PFIELD_NO_TYPE, invariant=PFIELD_NO_INVARIANT, initial=PFIELD_NO_
 def _check_field_parameters(field):
     for t in field.type:
         if not isinstance(t, type) and not isinstance(t, str):
-            raise TypeError('Type parameter expected, not {0}'.format(type(t)))
+            raise TypeError(f'Type parameter expected, not {type(t)}')
 
     if field.initial is not PFIELD_NO_INITIAL and \
             not callable(field.initial) and \
             field.type and not any(isinstance(field.initial, t) for t in field.type):
-        raise TypeError('Initial has invalid type {0}'.format(type(field.initial)))
+        raise TypeError(f'Initial has invalid type {type(field.initial)}')
 
     if not callable(field.invariant):
         raise TypeError('Invariant must be callable')
@@ -160,7 +160,7 @@ class PTypeError(TypeError):
     actual_type -- The non matching type
     """
     def __init__(self, source_class, field, expected_types, actual_type, *args, **kwargs):
-        super(PTypeError, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.source_class = source_class
         self.field = field
         self.expected_types = expected_types
@@ -297,7 +297,7 @@ def _make_pmap_field_type(key_type, value_type):
             return (_restore_pmap_field_pickle,
                     (self.__key_type__, self.__value_type__, dict(self)))
 
-    TheMap.__name__ = "{0}To{1}PMap".format(
+    TheMap.__name__ = "{}To{}PMap".format(
         _types_to_names(TheMap._checked_key_types),
         _types_to_names(TheMap._checked_value_types))
     _pmap_field_types[key_type, value_type] = TheMap

--- a/pyrsistent/_pbag.py
+++ b/pyrsistent/_pbag.py
@@ -131,7 +131,7 @@ class PBag(Generic[T_co]):
         return elt in self._counts
 
     def __repr__(self):
-        return "pbag({0})".format(list(self))
+        return f"pbag({list(self)})"
 
     def __eq__(self, other):
         """

--- a/pyrsistent/_pdeque.py
+++ b/pyrsistent/_pdeque.py
@@ -51,7 +51,7 @@ class PDeque(Generic[T_co]):
     __slots__ = ('_left_list', '_right_list', '_length', '_maxlen', '__weakref__')
 
     def __new__(cls, left_list, right_list, length, maxlen=None):
-        instance = super(PDeque, cls).__new__(cls)
+        instance = super().__new__(cls)
         instance._left_list = left_list
         instance._right_list = right_list
         instance._length = length
@@ -94,8 +94,8 @@ class PDeque(Generic[T_co]):
         return chain(self._left_list, self._right_list.reverse())
 
     def __repr__(self):
-        return "pdeque({0}{1})".format(list(self),
-                                       ', maxlen={0}'.format(self._maxlen) if self._maxlen is not None else '')
+        return "pdeque({}{})".format(list(self),
+                                       f', maxlen={self._maxlen}' if self._maxlen is not None else '')
     __str__ = __repr__
 
     @property
@@ -280,7 +280,7 @@ class PDeque(Generic[T_co]):
                 return PDeque(self._left_list,
                               self._right_list.reverse().remove(elem).reverse(), self._length - 1)
             except ValueError as e:
-                raise ValueError('{0} not found in PDeque'.format(elem)) from e
+                raise ValueError(f'{elem} not found in PDeque') from e
 
     def reverse(self):
         """
@@ -340,7 +340,7 @@ class PDeque(Generic[T_co]):
         shifted = len(self) + index
         if shifted < 0:
             raise IndexError(
-                "pdeque index {0} out of range {1}".format(index, len(self)),
+                f"pdeque index {index} out of range {len(self)}",
             )
         return self.popleft(shifted).left
 

--- a/pyrsistent/_plist.py
+++ b/pyrsistent/_plist.py
@@ -6,7 +6,7 @@ from typing import Generic, TypeVar
 T_co = TypeVar('T_co', covariant=True)
 
 
-class _PListBuilder(object):
+class _PListBuilder:
     """
     Helper class to allow construction of a list without
     having to reverse it in the end.
@@ -37,7 +37,7 @@ class _PListBuilder(object):
         return self._head
 
 
-class _PListBase(object):
+class _PListBase:
     __slots__ = ('__weakref__',)
 
     # Selected implementations can be taken straight from the Sequence
@@ -61,7 +61,7 @@ class _PListBase(object):
         return sum(1 for _ in self)
 
     def __repr__(self):
-        return "plist({0})".format(list(self))
+        return f"plist({list(self)})"
     __str__ = __repr__
 
     def cons(self, elem):
@@ -219,7 +219,7 @@ class _PListBase(object):
             builder.append_elem(head.first)
             head = head.rest
 
-        raise ValueError('{0} not found in PList'.format(elem))
+        raise ValueError(f'{elem} not found in PList')
 
 
 class PList(Generic[T_co], _PListBase):
@@ -252,7 +252,7 @@ class PList(Generic[T_co], _PListBase):
     __slots__ = ('first', 'rest')
 
     def __new__(cls, first, rest):
-        instance = super(PList, cls).__new__(cls)
+        instance = super().__new__(cls)
         instance.first = first
         instance.rest = rest
         return instance

--- a/pyrsistent/_pmap.py
+++ b/pyrsistent/_pmap.py
@@ -39,7 +39,7 @@ class PMapView:
         return len(self._map)
 
     def __setattr__(self, k, v):
-        raise TypeError("%s is immutable" % (type(self),))
+        raise TypeError(f"{type(self)} is immutable")
 
     def __reversed__(self):
         raise TypeError("Persistent maps are not reversible")
@@ -148,7 +148,7 @@ class PMap(Generic[KT, VT_co]):
     __slots__ = ('_size', '_buckets', '__weakref__', '_cached_hash')
 
     def __new__(cls, size, buckets):
-        self = super(PMap, cls).__new__(cls)
+        self = super().__new__(cls)
         self._size = size
         self._buckets = buckets
         return self
@@ -203,7 +203,7 @@ class PMap(Generic[KT, VT_co]):
             return self[key]
         except KeyError as e:
             raise AttributeError(
-                "{0} has no attribute '{1}'".format(type(self).__name__, key)
+                f"{type(self).__name__} has no attribute '{key}'"
             ) from e
 
     def iterkeys(self):
@@ -220,8 +220,7 @@ class PMap(Generic[KT, VT_co]):
     def iteritems(self):
         for bucket in self._buckets:
             if bucket:
-                for k, v in bucket:
-                    yield k, v
+                yield from bucket
 
     def values(self):
         return PMapValues(self)
@@ -237,7 +236,7 @@ class PMap(Generic[KT, VT_co]):
         return self._size
 
     def __repr__(self):
-        return 'pmap({0})'.format(str(dict(self)))
+        return f'pmap({str(dict(self))})'
 
     def __eq__(self, other):
         if self is other:
@@ -391,7 +390,7 @@ class PMap(Generic[KT, VT_co]):
     def copy(self):
         return self
 
-    class _Evolver(object):
+    class _Evolver:
         __slots__ = ('_buckets_evolver', '_size', '_original_pmap')
 
         def __init__(self, original_pmap):
@@ -485,7 +484,7 @@ class PMap(Generic[KT, VT_co]):
                     self._size -= size_diff
                     return self
 
-            raise KeyError('{0}'.format(key))
+            raise KeyError(f'{key}')
 
     def evolver(self):
         """

--- a/pyrsistent/_pset.py
+++ b/pyrsistent/_pset.py
@@ -31,7 +31,7 @@ class PSet(Generic[T_co]):
     __slots__ = ('_map', '__weakref__')
 
     def __new__(cls, m):
-        self = super(PSet, cls).__new__(cls)
+        self = super().__new__(cls)
         self._map = m
         return self
 
@@ -48,7 +48,7 @@ class PSet(Generic[T_co]):
         if not self:
             return 'p' + str(set(self))
 
-        return 'pset([{0}])'.format(str(set(self))[1:-1])
+        return f'pset([{str(set(self))[1:-1]}])'
 
     def __str__(self):
         return self.__repr__()
@@ -62,7 +62,7 @@ class PSet(Generic[T_co]):
 
     @classmethod
     def _from_iterable(cls, it, pre_size=8):
-        return PSet(pmap(dict((k, True) for k in it), pre_size=pre_size))
+        return PSet(pmap({k: True for k in it}, pre_size=pre_size))
 
     def add(self, element):
         """
@@ -110,7 +110,7 @@ class PSet(Generic[T_co]):
 
         return self
 
-    class _Evolver(object):
+    class _Evolver:
         __slots__ = ('_original_pset', '_pmap_evolver')
 
         def __init__(self, original_pset):

--- a/pyrsistent/_pvector.py
+++ b/pyrsistent/_pvector.py
@@ -28,14 +28,14 @@ def _index_or_slice(index, stop):
     return slice(index, stop)
 
 
-class PythonPVector(object):
+class PythonPVector:
     """
     Support structure for PVector that implements structural sharing for vectors using a trie.
     """
     __slots__ = ('_count', '_shift', '_root', '_tail', '_tail_offset', '__weakref__')
 
     def __new__(cls, count, shift, root, tail):
-        self = super(PythonPVector, cls).__new__(cls)
+        self = super().__new__(cls)
         self._count = count
         self._shift = shift
         self._root = root
@@ -68,7 +68,7 @@ class PythonPVector(object):
         return self.extend(other)
 
     def __repr__(self):
-        return 'pvector({0})'.format(str(self.tolist()))
+        return f'pvector({str(self.tolist())})'
 
     def __str__(self):
         return self.__repr__()
@@ -151,7 +151,7 @@ class PythonPVector(object):
 
         return evolver.persistent()
 
-    class Evolver(object):
+    class Evolver:
         __slots__ = ('_count', '_shift', '_root', '_tail', '_tail_offset', '_dirty_nodes',
                      '_extra_tail', '_cached_leafs', '_orig_pvector')
 
@@ -217,7 +217,7 @@ class PythonPVector(object):
             elif index == self._count + len(self._extra_tail):
                 self._extra_tail.append(val)
             else:
-                raise IndexError("Index out of range: %s" % (index,))
+                raise IndexError(f"Index out of range: {index}")
 
         def _do_set(self, level, node, i, val):
             if id(node) in self._dirty_nodes:
@@ -288,7 +288,7 @@ class PythonPVector(object):
         if i == self._count:
             return self.append(val)
 
-        raise IndexError("Index out of range: %s" % (i,))
+        raise IndexError(f"Index out of range: {i}")
 
     def _do_set(self, level, node, i, val):
         ret = list(node)
@@ -312,7 +312,7 @@ class PythonPVector(object):
 
             return node
 
-        raise IndexError("Index out of range: %s" % (i,))
+        raise IndexError(f"Index out of range: {i}")
 
     def _create_new_root(self):
         new_shift = self._shift

--- a/pyrsistent/typing.py
+++ b/pyrsistent/typing.py
@@ -11,7 +11,6 @@ For example,
     myvector: PVector[str] = pvector(['a', 'b', 'c'])
 
 """
-from __future__ import absolute_import
 
 try:
     from typing import Container

--- a/tests/checked_map_test.py
+++ b/tests/checked_map_test.py
@@ -79,7 +79,7 @@ def test_multi_level_serialization():
     assert str(x) == "IntToFloatSetMap({1: FloatSet([1.5, 1.25]), 2: FloatSet([2.75, 2.5])})"
 
     sx = x.serialize()
-    assert sx == {1: set([1.5, 1.25]), 2: set([2.75, 2.5])}
+    assert sx == {1: {1.5, 1.25}, 2: {2.75, 2.5}}
     assert isinstance(sx[1], set)
 
 def test_create_non_checked_types():

--- a/tests/checked_set_test.py
+++ b/tests/checked_set_test.py
@@ -41,7 +41,7 @@ def test_repr():
 def test_default_serialization():
     x = Naturals([1, 2])
 
-    assert x.serialize() == set([1, 2])
+    assert x.serialize() == {1, 2}
 
 class StringNaturals(Naturals):
     @staticmethod
@@ -51,7 +51,7 @@ class StringNaturals(Naturals):
 def test_custom_serialization():
     x = StringNaturals([1, 2])
 
-    assert x.serialize("{0}") == set(["1", "2"])
+    assert x.serialize("{0}") == {"1", "2"}
 
 class NaturalsVector(CheckedPVector):
     __type__ = Naturals
@@ -62,7 +62,7 @@ def test_multi_level_serialization():
     assert str(x) == "NaturalsVector([Naturals([1, 2]), Naturals([3, 4])])"
 
     sx = x.serialize()
-    assert sx == [set([1, 2]), set([3, 4])]
+    assert sx == [{1, 2}, {3, 4}]
     assert isinstance(sx[0], set)
 
 def test_create():

--- a/tests/class_test.py
+++ b/tests/class_test.py
@@ -297,7 +297,7 @@ def test_multiple_invariants_on_field():
         MultiInvariantField(one=1, two=2)
         assert False
     except InvariantException as e:
-        assert set(e.invariant_errors) == set([('one_one', 'one_two'), 'two_one'])
+        assert set(e.invariant_errors) == {('one_one', 'one_two'), 'two_one'}
 
 
 def test_multiple_global_invariants():
@@ -313,7 +313,7 @@ def test_multiple_global_invariants():
 
 
 def test_inherited_global_invariants():
-    class Distant(object):
+    class Distant:
         def __invariant__(self):
             return [(self.distant, "distant")]
 
@@ -334,7 +334,7 @@ def test_inherited_global_invariants():
 
 def test_diamond_inherited_global_invariants():
     counter = []
-    class Base(object):
+    class Base:
         def __invariant__(self):
             counter.append(None)
             return [(False, "base")]
@@ -402,7 +402,7 @@ def test_invariant_checks_static_initial_value():
 
 def test_lazy_invariant_message():
     class MyClass(PClass):
-        a = field(int, invariant=lambda x: (x < 5, lambda: "{x} is too large".format(x=x)))
+        a = field(int, invariant=lambda x: (x < 5, lambda: f"{x} is too large"))
 
     try:
         MyClass(a=5)
@@ -467,7 +467,7 @@ def test_value_can_be_overridden_in_subclass_new():
             items = kwargs.get('y', None)
             if items is None:
                 kwargs['y'] = ()
-            return super(X, cls).__new__(cls, **kwargs)
+            return super().__new__(cls, **kwargs)
 
     a = X(y=[])
     b = a.set(y=None)

--- a/tests/freeze_test.py
+++ b/tests/freeze_test.py
@@ -25,7 +25,7 @@ def test_freeze_defaultdict():
     assert type(freeze({'a': 'b'})) is type(m())
 
 def test_freeze_set():
-    result = freeze(set([1, 2, 3]))
+    result = freeze({1, 2, 3})
     assert result == s(1, 2, 3)
     assert type(result) is type(s())
 
@@ -106,7 +106,7 @@ def test_thaw_dict():
 
 def test_thaw_set():
     result = thaw(s(1, 2))
-    assert result == set([1, 2])
+    assert result == {1, 2}
     assert type(result) is set
 
 def test_thaw_recurse_in_mapping_values():

--- a/tests/hypothesis_vector_test.py
+++ b/tests/hypothesis_vector_test.py
@@ -24,7 +24,7 @@ class RefCountTracker:
         self.id = id(self)
 
     def __repr__(self):
-        return "<%s>" % (self.id,)
+        return f"<{self.id}>"
 
     def __del__(self):
         # If self is a dangling memory reference this check might fail. Or

--- a/tests/immutable_object_test.py
+++ b/tests/immutable_object_test.py
@@ -15,7 +15,7 @@ class FrozenMember(immutable('x, y_')):
 
 class DerivedWithNew(immutable(['x', 'y'])):
     def __new__(cls, x, y):
-        return super(DerivedWithNew, cls).__new__(cls, x, y)
+        return super().__new__(cls, x, y)
 
 
 def test_instantiate_object_with_no_members():

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -90,7 +90,7 @@ def test_initialization_with_two_elements():
 
 
 def test_initialization_with_many_elements():
-    init_dict = dict([(str(x), x) for x in range(1700)])
+    init_dict = {str(x): x for x in range(1700)}
     the_map = pmap(init_dict)
 
     assert len(the_map) == 1700
@@ -136,7 +136,7 @@ def test_hash():
 
 
 def test_same_hash_when_content_the_same_but_underlying_vector_size_differs():
-    x = pmap(dict((x, x) for x in range(1000)))
+    x = pmap({x: x for x in range(1000)})
     y = pmap({10: 10, 200: 200, 700: 700})
 
     for z in x:
@@ -147,7 +147,7 @@ def test_same_hash_when_content_the_same_but_underlying_vector_size_differs():
     assert hash(x) == hash(y)
 
 
-class HashabilityControlled(object):
+class HashabilityControlled:
     hashable = True
 
     def __hash__(self):
@@ -277,7 +277,7 @@ def test_transform_levels_missing():
     assert x.transform(['b', 'd', 'e'], 999) == m(a=1, b=m(c=3, d=m(e=999)))
 
 
-class HashDummy(object):
+class HashDummy:
     def __hash__(self):
         return 6528039219058920  # Hash of '33'
 

--- a/tests/performance_run.py
+++ b/tests/performance_run.py
@@ -219,14 +219,14 @@ def run_len():
     for _ in range(r):
         len(v)
     len_duration = time.time() - before
-    print("Len: %s s, per call %s s" % (len_duration, len_duration / r))
+    print(f"Len: {len_duration} s, per call {len_duration / r} s")
 
     before = time.time()
     for _ in range(r):
         pass
     empty_duration = time.time() - before
-    print("Empty loop: %s s, per call %s s" % (empty_duration, empty_duration / r))
-    print("Len estimate: %s, per call: %s" % (len_duration - empty_duration, (len_duration - empty_duration) / r))
+    print(f"Empty loop: {empty_duration} s, per call {empty_duration / r} s")
+    print(f"Len estimate: {len_duration - empty_duration}, per call: {(len_duration - empty_duration) / r}")
 
 def random_access(s):
     testdata = [0, 4, 55, 10000, 98763, -2, 30000, 42004, 37289, 100, 2, 999999]
@@ -256,7 +256,7 @@ def run_multiple_random_inserts():
     for r in range(10000):
         for i in indices:
             new = new.set(i, 0)
-    print("Done simple, time=%s s, iterations=%s" % (time.time() - start, 10000 * len(indices)))
+    print(f"Done simple, time={time.time() - start} s, iterations={10000 * len(indices)}")
     assert original == original2
 
     # Using setter view
@@ -266,14 +266,13 @@ def run_multiple_random_inserts():
         for i in indices:
             evolver[i] = 0
     new2 = evolver.persistent()
-    print("Done evolver, time=%s s, iterations=%s" % (time.time() - start, 10000 * len(indices)))
+    print(f"Done evolver, time={time.time() - start} s, iterations={10000 * len(indices)}")
 
     assert original == original2
 
     def interleave(it1, it2):
         for i in zip(it1, it2):
-            for j in i:
-                yield j
+            yield from i
 
     # Using mset
     start = time.time()
@@ -281,7 +280,7 @@ def run_multiple_random_inserts():
     args = list(interleave(indices, repeat(0)))
     for _ in range(10000):
         new3 = new3.mset(*args)
-    print("Done mset, time=%s s, iterations=%s" % (time.time() - start, 10000 * len(args)/2))
+    print(f"Done mset, time={time.time() - start} s, iterations={10000 * len(args)/2}")
 
     assert list(new) == list(new2)
     assert list(new2) == list(new3)
@@ -299,14 +298,14 @@ def run_multiple_inserts_in_pmap():
     # Using ordinary set
     start = time.time()
     m1 = pmap(elements)
-    print("Done initializing, time=%s s, count=%s" % (time.time() - start, COUNT))
+    print(f"Done initializing, time={time.time() - start} s, count={COUNT}")
 
 
     start = time.time()
     m2 = pmap()
     for x in test_range():
         m2 = m2.set(x, x)
-    print("Done setting, time=%s s, count=%s" % (time.time() - start, COUNT))
+    print(f"Done setting, time={time.time() - start} s, count={COUNT}")
 
     assert m1 == m2
 
@@ -316,7 +315,7 @@ def run_multiple_inserts_in_pmap():
     for x in test_range():
         e3[x] = x
     m3 = e3.persistent()
-    print("Done evolving, time=%s s, count=%s" % (time.time() - start, COUNT))
+    print(f"Done evolving, time={time.time() - start} s, count={COUNT}")
 
     assert m3 == m2
 
@@ -324,7 +323,7 @@ def run_multiple_inserts_in_pmap():
     m4 = pmap()
     m4 = m4.update(elements)
     m4 = m4.update(elements)
-    print("Done updating, time=%s s, count=%s" % (time.time() - start, COUNT))
+    print(f"Done updating, time={time.time() - start} s, count={COUNT}")
 
     assert m4 == m3
 
@@ -332,7 +331,7 @@ def run_multiple_inserts_in_pmap():
     m5 = pmap()
     m5 = m5.update_with(lambda l, r: r, elements)
     m5 = m5.update_with(lambda l, r: r, elements)
-    print("Done updating with, time=%s s, count=%s" % (time.time() - start, COUNT))
+    print(f"Done updating with, time={time.time() - start} s, count={COUNT}")
 
     assert m5 == m4
 

--- a/tests/record_test.py
+++ b/tests/record_test.py
@@ -29,10 +29,10 @@ class UniqueThing(PRecord):
     id = field(type=uuid.UUID, factory=uuid.UUID)
 
 
-class Something(object):
+class Something:
     pass
 
-class Another(object):
+class Another:
     pass
 
 def test_create_ignore_extra_true():
@@ -118,8 +118,8 @@ def test_cannot_assign_wrong_type_to_fields():
     except PTypeError as e:
         assert e.source_class == ARecord
         assert e.field == 'x'
-        assert e.expected_types == set([int, float])
-        assert e.actual_type is type('foo')
+        assert e.expected_types == {int, float}
+        assert e.actual_type is str
 
 
 def test_cannot_construct_with_undeclared_fields():
@@ -329,7 +329,7 @@ def test_all_invariant_errors_reported():
         CRecord.create({'a': 0, 'b': {'x': -5}})
         assert False
     except InvariantException as e:
-        assert set(e.invariant_errors) == set(['x negative', 'a zero'])
+        assert set(e.invariant_errors) == {'x negative', 'a zero'}
         assert e.missing_fields == ('BRecord.y',)
 
 

--- a/tests/vector_test.py
+++ b/tests/vector_test.py
@@ -917,7 +917,7 @@ def test_get_evolver_referents(pvector):
 
 def test_failing_repr(pvector):
     # See https://github.com/tobgu/pyrsistent/issues/84
-    class A(object):
+    class A:
         def __repr__(self):
             raise ValueError('oh no!')
 


### PR DESCRIPTION
This is a purely mechanical change; no manual work was performed.

Older Python syntax was automatically updated to newer syntax, and old requirements were automatically removed.

Notable examples:

* Inheriting from `object` (`class A(object):` -> `class A:`)
* Super usage (`super(Class, instance)` -> `super()`)
* U-strings removed (`u"x"` -> `"x"`)
* F-strings (`"{}".format(x)` -> `f"{x}"`)
* Set literal syntax (`set([1, 2])` -> `{1, 2}`)
* Set and dictionary comprehensions