### PR TITLE
Overhaul testing for better coverage reporting

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 build/
 pyrsistent.egg-info/
 dist/
+htmlcov/
 .idea
 .tox
 README.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,30 @@
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
+
+
+# coverage
+# --------
+
+[tool.coverage.run]
+relative_files = true
+parallel = true
+branch = true
+source = [
+    "pyrsistent",
+    "tests",
+]
+
+[tool.coverage.paths]
+source = [
+    "src",
+    "*/site-packages",
+]
+
+[tool.coverage.report]
+skip_covered = true
+fail_under = 92
+
+[tool.coverage.html]
+directory = "htmlcov/"
+skip_covered = false

--- a/tox.ini
+++ b/tox.ini
@@ -5,49 +5,59 @@
 
 [tox]
 envlist =
-    py{3.12, 3.11, 3.10, 3.9, 3.8}
+    coverage-erase
+    # When updating the following lines, use search-and-replace.
+    # This will ensure consistent updates through this file,
+    # which is very important for parallel execution.
+    py{3.12, 3.11, 3.10, 3.9, 3.8}{,-no_c_extension}
     pypy{3.10}
+    coverage-report
     memorytest38
     doctest38
-    coverage-py38
 
 [gh-actions]
 python =
+    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
 
-# Skipping 3.8 under GH actions for now. Need to fix coverage first.
-
 [testenv]
-commands = pytest
+depends =
+    py{3.12, 3.11, 3.10, 3.9, 3.8}{,-no_c_extension}: coverage-erase
+    pypy{3.10}: coverage-erase
 deps =
+    coverage[toml]
     pytest
     hypothesis
-
-# Specifying the following tests like this is very non-DRY but I have no better solution right now.
-[testenv:coverage-py38]
-# Skip using C-extension to get coverage metrics on Python code.
-basepython = python3.8
-passenv =
-    TRAVIS
-    TRAVIS_BRANCH
-    TRAVIS_JOB_ID
 setenv =
-    PYRSISTENT_NO_C_EXTENSION = 1
-deps =
-    setuptools
-    pytest
-    hypothesis
-    pytest-cov
-    coveralls
-changedir = tests
+    # If the `-no_c_extension` factor is set, disable the C extension.
+    no_c_extension: PYRSISTENT_NO_C_EXTENSION = 1
 commands =
-    pytest --cov=pyrsistent
-    # Ignore the coveralls return code.
-    # This allows the tox environment to be run locally without errors.
-    - coveralls
+    coverage run -m pytest
+
+[testenv:coverage-erase]
+description = Erase existing coverage files, if any
+skip_install = true
+deps =
+    coverage[toml]
+commands =
+    - coverage erase
+
+[testenv:coverage-report]
+description = Report coverage numbers and generate an HTML report
+skip_install = true
+depends =
+    py{3.12, 3.11, 3.10, 3.9, 3.8}{,-no_c_extension}
+    pypy{3.10}
+deps =
+    coverage[toml]
+commands_pre =
+    - coverage combine
+    - coverage html
+commands =
+    coverage report
 
 [testenv:memorytest38]
 basepython = python3.8


### PR DESCRIPTION
This introduces the following changes:

* All CPython versions are tested with and without the C extension (locally).
* Coverage is tracked for all Python interpreter versions, and is then combined to give a total report. A report is output during tox execution, and an HTML report is written to `htmlcov/`.
* Travis CI and coveralls are removed, as they are unused in GitHub CI and locally.
* CPython 3.8 is tested in CI now.
* Tox environment dependencies are now set, so the test suite can be executed in parallel using `tox run-parallel` or simply `tox p`.

----

# Coverage report screenshot

> ![image](https://github.com/user-attachments/assets/b29f7b25-1b23-418e-b904-b21ca02dda9c)

----

After reviewing the coverage report, there are some improvement opportunities in the test suite. For example, this paradigm is used several places:

```python
try:
    cause_a_crash()
    assert False
except ValueError as e:
    assert e.something == "expected"
```

This can be replaced with pytest constructs:

```python
with pytest.raises(ValueError) as e:
    cause_a_crash()
assert e.something == "expected"
```

This can be done in subsequent work.