### PR TITLE
initialize `refCount` in `doSetWithDirty`

### DIFF
--- a/pvectorcmodule.c
+++ b/pvectorcmodule.c
@@ -1357,6 +1357,7 @@ static VNode* doSetWithDirty(VNode* node, unsigned int level, unsigned int posit
     if(!IS_DIRTY(node)) {
       resultNode = allocNode();
       copyInsert(resultNode->items, node->items, position & BIT_MASK, value);
+      SET_NODE_REF_COUNT(resultNode, 1);
       incRefs((PyObject**)resultNode->items);
       SET_DIRTY(resultNode);
     } else {


### PR DESCRIPTION
Fixes [#319](https://github.com/tobgu/pyrsistent/issues/319)

`doSetWithDirty` allocates a new `VNode` via `allocNode`, but does not
initialize the `refCount` field. As a result, `releaseNode` may later
read an uninitialized value, triggering Valgrind warnings and undefined
behavior.
This PR explicitly initializes `resultNode->refCount` in `doSetWithDirty` after
calling `allocNode`.