### PR TITLE
Add windows arm64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           - manylinux_x86_64
           - manylinux_aarch64
           - win_amd64
+          - win_arm64
 
         include:
           # Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
           # Windows
           - platform_id: win_amd64
             os: windows-latest
+          - platform_id: win_arm64
+            os: windows-11-arm
 
     env:
       CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}


### PR DESCRIPTION
Closes #321 

This would add windows arm64 builds to the `build.yml` workflow.